### PR TITLE
fix(server): make resolveDocDiskPath robust to cwd (#4)

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1303,26 +1303,56 @@ func truncateRunesStr(s string, maxRunes int) string {
 	return string(r[:maxRunes])
 }
 
-// resolveDocDiskPath finds bytes on disk if the RAG-stored path is stale (cwd/data dir changed).
+// resolveDocDiskPath finds bytes on disk if the RAG-stored path is stale
+// (cwd/data dir changed). It is robust to the current working directory,
+// relative vs absolute configured DataDir, and filenames containing unicode
+// or spaces. The canonical location (DataDir/docs/<basename>) is checked
+// first so uploaded bytes are found even if the RAG index stored a stale path.
 func (s *Server) resolveDocDiskPath(doc model.DocumentRecord) (abs string, ok bool) {
-	candidates := []string{
-		doc.Path,
-		filepath.Join(s.cfg.DataDir, "docs", filepath.Base(doc.Path)),
+	base := filepath.Base(doc.Path)
+	if base == "" || base == "." || base == string(filepath.Separator) {
+		base = filepath.Base(doc.Filename)
 	}
-	if wd, err := os.Getwd(); err == nil {
-		if !filepath.IsAbs(doc.Path) {
+
+	// Resolve DataDir against cwd if it is relative, so lookups work no
+	// matter where the server was launched from.
+	dataDir := s.cfg.DataDir
+	wd, wdErr := os.Getwd()
+	var absDataDir string
+	if filepath.IsAbs(dataDir) {
+		absDataDir = dataDir
+	} else if wdErr == nil {
+		absDataDir = filepath.Join(wd, dataDir)
+	}
+
+	// Canonical location first — DataDir/docs/<basename> — so uploaded
+	// bytes are found even when the RAG index stored a stale path.
+	candidates := []string{}
+	if absDataDir != "" {
+		candidates = append(candidates, filepath.Join(absDataDir, "docs", base))
+	}
+	if dataDir != "" && dataDir != absDataDir {
+		candidates = append(candidates, filepath.Join(dataDir, "docs", base))
+	}
+	if doc.Path != "" {
+		candidates = append(candidates, doc.Path)
+		if !filepath.IsAbs(doc.Path) && wdErr == nil {
 			candidates = append(candidates, filepath.Join(wd, doc.Path))
 		}
-		candidates = append(candidates, filepath.Join(wd, s.cfg.DataDir, "docs", filepath.Base(doc.Path)))
 	}
+
 	seen := map[string]bool{}
 	for _, p := range candidates {
-		if p == "" || seen[p] {
+		if p == "" {
 			continue
 		}
-		seen[p] = true
-		if fi, err := os.Stat(p); err == nil && !fi.IsDir() {
-			return p, true
+		cleaned := filepath.Clean(p)
+		if seen[cleaned] {
+			continue
+		}
+		seen[cleaned] = true
+		if fi, err := os.Stat(cleaned); err == nil && !fi.IsDir() {
+			return cleaned, true
 		}
 	}
 	return doc.Path, false


### PR DESCRIPTION
## Summary
- Root cause of issue #4 (`/v1/documents/:id/view` returning 404 or wrong file).
- `resolveDocDiskPath` was fragile to cwd changes: it joined the RAG-stored `doc.Path` against the current working directory, which only works if cwd equals the data root.
- Fix: always check `DataDir/docs/<basename>` first (the canonical location), then resolve relative DataDir against cwd, then fall back to the RAG-stored path. Dedupe candidates via `filepath.Clean`.
- Unicode and space filenames pass through unchanged — the caller already runs `unescapeURLPathSegment`.

## Test plan
- [x] `go vet ./... && go test ./internal/server/...` pass locally
- [ ] E2E: upload a doc, stop server, restart from a different cwd, fetch `/v1/documents/<name>/view` — should return content (previously 404)

Closes #4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: localized change to document file path resolution, but it affects `/v1/documents/:id/view` and could cause regressions in file lookup on unusual DataDir/path setups.
> 
> **Overview**
> Fixes document viewing failures when the stored `doc.Path` becomes stale after restarting the server from a different working directory.
> 
> `resolveDocDiskPath` now derives a safer basename (falling back to `doc.Filename`), resolves relative `DataDir` against the current working directory, prioritizes the canonical `DataDir/docs/<basename>` location before any RAG-stored path, and dedupes/stat-checks candidates using `filepath.Clean`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a28d90789330844342ba8b7339b8b179d652ad92. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of document path resolution when server launch configuration or working directory changes, ensuring documents are reliably located across different environments.
  * Enhanced handling of edge cases in file path normalization and deduplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->