### PR TITLE
security(ws): harden CheckOrigin (loopback + same-host + env allowlist)

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -26,6 +26,36 @@ import (
 	"github.com/gorilla/websocket"
 )
 
+// checkWebSocketOrigin accepts same-host and loopback origins by default,
+// and allows additional origins via the AGENTFLOW_ALLOW_ORIGINS env var
+// (comma-separated list of full origins, e.g. "https://app.example.com").
+// Requests with no Origin header (non-browser clients like curl) are allowed.
+func checkWebSocketOrigin(r *http.Request) bool {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return true
+	}
+	u, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(u.Hostname())
+	if host == "127.0.0.1" || host == "::1" || host == "localhost" {
+		return true
+	}
+	if strings.EqualFold(u.Host, r.Host) {
+		return true
+	}
+	if allow := os.Getenv("AGENTFLOW_ALLOW_ORIGINS"); allow != "" {
+		for _, a := range strings.Split(allow, ",") {
+			if strings.EqualFold(strings.TrimSpace(a), origin) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 type Server struct {
 	cfg        *config.Config
 	llm        *llm.Provider
@@ -58,9 +88,7 @@ func New(cfg *config.Config) *Server {
 		upgrader: websocket.Upgrader{
 			ReadBufferSize:  1024,
 			WriteBufferSize: 1024,
-			CheckOrigin: func(r *http.Request) bool {
-				return true
-			},
+			CheckOrigin:     checkWebSocketOrigin,
 		},
 	}
 


### PR DESCRIPTION
## Summary
The WebSocket upgrader's `CheckOrigin` returned `true` unconditionally, exposing a cross-site WebSocket hijacking surface. Now:
- Loopback (`127.0.0.1`, `::1`, `localhost`) and same-host origins are accepted by default.
- Empty `Origin` (curl / non-browser) is accepted so local tooling keeps working.
- Additional origins can be allowlisted via `AGENTFLOW_ALLOW_ORIGINS` (comma-separated full origins).

## Test plan
- [x] `go vet ./... && go test ./internal/server/...` pass
- [ ] Manual: `curl -H 'Origin: https://evil.example' ... /ws` returns 403; same-host upgrade still 101

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens WebSocket `CheckOrigin`, which can break existing browser clients behind proxies or on alternate domains unless the correct origin/host headers or `AGENTFLOW_ALLOW_ORIGINS` are configured. Change is security-sensitive but scoped to the WS upgrade path.
> 
> **Overview**
> **Hardens WebSocket origin validation** by replacing the unconditional `CheckOrigin` with `checkWebSocketOrigin`.
> 
> The server now only accepts WebSocket upgrades from *loopback* and *same-host* origins by default, allows non-browser clients with no `Origin` header, and supports an explicit comma-separated origin allowlist via `AGENTFLOW_ALLOW_ORIGINS`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fb7a08bc02bf938c3c1d3ef44a9dc775b63afb1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->