### PR TITLE
fix(ui): log background-poll errors instead of swallowing (#20)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -724,7 +724,7 @@
                 try {
                     const r = await fetch(`${API}/status`);
                     State.update(await r.json());
-                } catch (e) {}
+                } catch (e) { console.warn("refreshAll failed", e); }
             },
 
             async selectCase(id) { await State.fetchFullCase(id); },
@@ -944,7 +944,7 @@
                     document.getElementById("sys-platform").textContent = d.platform_id;
                     document.getElementById("sys-memory").textContent = d.memory_mb + " MB";
                     document.getElementById("sys-apple").textContent = d.is_apple_silicon ? "Yes" : "No";
-                } catch (e) {}
+                } catch (e) { console.warn("fetchSystemStatus failed", e); }
             },
 
             async advanceState(ev) {
@@ -1046,7 +1046,7 @@
                 State.update(d);
                 document.getElementById("conn-dot").className = "h-1.5 w-1.5 rounded-full bg-amber-500";
                 document.getElementById("conn-text").textContent = "Live (HTTP)";
-            } catch (e) {}
+            } catch (e) { console.warn("pollStatusIfWSDead failed", e); }
         }
 
         setInterval(pollStatusIfWSDead, 4000);


### PR DESCRIPTION
## Summary
Three bare `catch (e) {}` blocks in polling paths (`refreshAll`, `fetchSystemStatus`, `pollStatusIfWSDead`) now `console.warn` on failure. Still no toasts — these are background polls and toasting would be noisy — but the errors are visible in devtools.

## Test plan
- [ ] Stop backend, observe repeated `refreshAll failed` warnings in console (instead of silent failure)

Closes #20