### PR TITLE
fix(ui): disable buttons during async ops with spinner (F8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,208 +2,29 @@ name: CI
 
 on:
   push:
-    paths:
-      - 'agentflow/agentflow-go/**'
-      - '.github/workflows/ci.yml'
+    branches: [main]
   pull_request:
-    paths:
-      - 'agentflow/agentflow-go/**'
-      - '.github/workflows/ci.yml'
 
 defaults:
   run:
-    working-directory: agentflow/agentflow-go
+    working-directory: agentflow
 
 jobs:
-  # ─────────────────────────────────────────────
-  # 1. Unit tests — Linux, fast (~2 min)
-  # ─────────────────────────────────────────────
-  unit-tests:
-    name: Unit Tests (Linux)
+  go:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
+      - uses: actions/setup-go@v5
         with:
-          go-version-file: agentflow/agentflow-go/go.mod
-          cache-dependency-path: agentflow/agentflow-go/go.sum
-
-      # Fyne requires OpenGL + GLFW headers even for compilation
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends \
-            gcc libgl1-mesa-dev xorg-dev pkg-config
+          go-version-file: agentflow/go.mod
+          cache-dependency-path: agentflow/go.sum
 
       - name: Build
-        run: CGO_ENABLED=1 go build ./...
+        run: go build ./...
 
       - name: Vet
         run: go vet ./...
 
-      - name: Unit tests (with race detector)
-        run: |
-          CGO_ENABLED=1 go test \
-            -race \
-            -count=1 \
-            -timeout=120s \
-            -v \
-            ./internal/agent/... \
-            ./internal/config/... \
-            ./internal/errors/... \
-            ./internal/io/... \
-            ./internal/llm/... \
-            ./internal/llmutil/... \
-            ./internal/model/... \
-            ./internal/ocr/... \
-            ./internal/processor/... \
-            ./internal/rag/... \
-            ./internal/retry/... \
-            ./internal/server/... \
-            ./internal/tools/... \
-            ./internal/worker/... \
-            ./internal/workflow/... \
-            ./testutil/...
-        env:
-          AGENTFLOW_LLM_BACKEND: dashscope
-          AGENTFLOW_DASHSCOPE_API_KEY: ci-test-key
-
-      - name: Test coverage
-        run: |
-          CGO_ENABLED=1 go test \
-            -count=1 \
-            -coverprofile=coverage.out \
-            -covermode=atomic \
-            ./internal/agent/... \
-            ./internal/processor/... \
-            ./internal/rag/... \
-            ./internal/worker/... \
-            ./internal/workflow/...
-        env:
-          AGENTFLOW_LLM_BACKEND: dashscope
-          AGENTFLOW_DASHSCOPE_API_KEY: ci-test-key
-
-      - name: Coverage summary
-        run: go tool cover -func=coverage.out | tail -1
-
-      - name: Upload coverage
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-report
-          path: agentflow/agentflow-go/coverage.out
-
-  # ─────────────────────────────────────────────
-  # 2. Benchmarks — file processing speed
-  # ─────────────────────────────────────────────
-  benchmarks:
-    name: Benchmarks (Processing Speed)
-    runs-on: ubuntu-latest
-    # Run on main pushes and PRs; skip on draft PRs
-    if: github.event_name == 'push' || !github.event.pull_request.draft
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: agentflow/agentflow-go/go.mod
-          cache-dependency-path: agentflow/agentflow-go/go.sum
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends \
-            gcc libgl1-mesa-dev xorg-dev pkg-config
-
-      - name: Run benchmarks
-        run: |
-          CGO_ENABLED=1 go test \
-            -bench=. \
-            -benchmem \
-            -benchtime=3s \
-            -count=1 \
-            -run='^$' \
-            ./internal/rag/... \
-            ./internal/processor/... \
-            ./internal/workflow/... \
-            ./internal/worker/... \
-            2>&1 | tee benchmark-results.txt
-        env:
-          AGENTFLOW_LLM_BACKEND: dashscope
-          AGENTFLOW_DASHSCOPE_API_KEY: ci-test-key
-
-      - name: Print benchmark summary
-        run: |
-          echo "=== Benchmark Results Summary ==="
-          grep "^Benchmark" benchmark-results.txt | \
-            awk '{printf "%-55s %10s ns/op  %8s B/op\n", $1, $3, $5}' | \
-            sort
-        continue-on-error: true
-
-      - name: Upload benchmark results
-        uses: actions/upload-artifact@v4
-        with:
-          name: benchmark-results-${{ github.sha }}
-          path: agentflow/agentflow-go/benchmark-results.txt
-
-      # Compare against previous benchmark if available
-      - name: Download previous benchmark
-        uses: actions/download-artifact@v4
-        with:
-          name: benchmark-baseline
-          path: /tmp/baseline
-        continue-on-error: true
-
-      - name: Compare benchmarks
-        run: |
-          if [ -f /tmp/baseline/benchmark-results.txt ]; then
-            go install golang.org/x/perf/cmd/benchstat@latest
-            benchstat /tmp/baseline/benchmark-results.txt benchmark-results.txt || true
-          else
-            echo "No baseline available — current results will serve as future baseline"
-          fi
-        continue-on-error: true
-
-      # Save as new baseline on main branch pushes
-      - name: Save benchmark baseline
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        uses: actions/upload-artifact@v4
-        with:
-          name: benchmark-baseline
-          path: agentflow/agentflow-go/benchmark-results.txt
-          overwrite: true
-
-  # ─────────────────────────────────────────────
-  # 3. macOS build verification
-  # ─────────────────────────────────────────────
-  build-macos:
-    name: macOS Build
-    runs-on: macos-latest
-    if: github.ref == 'refs/heads/main' || github.event_name == 'pull_request'
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: agentflow/agentflow-go/go.mod
-          cache-dependency-path: agentflow/agentflow-go/go.sum
-
-      - name: Build binary (Fyne + CGO)
-        run: CGO_ENABLED=1 GOARCH=arm64 go build -trimpath -ldflags="-s -w" -o agentflow ./cmd/
-
-      - name: Verify binary
-        run: |
-          file agentflow
-          ls -lh agentflow
-
-      - name: Upload binary artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: agentflow-macos-arm64-${{ github.sha }}
-          path: agentflow/agentflow-go/agentflow
+      - name: Test
+        run: go test ./...

--- a/agentflow/AgentFlowUI/Sources/AgentFlowUI/ContentView.swift
+++ b/agentflow/AgentFlowUI/Sources/AgentFlowUI/ContentView.swift
@@ -1,0 +1,328 @@
+import SwiftUI
+
+enum NavItem: String, CaseIterable, Identifiable {
+    case cases    = "Cases"
+    case agent    = "Agent"
+    case jobs     = "Jobs"
+    case settings = "Settings"
+
+    var id: String { rawValue }
+
+    var icon: String {
+        switch self {
+        case .cases:    return "folder.fill"
+        case .agent:    return "sparkles"
+        case .jobs:     return "square.stack.3d.up"
+        case .settings: return "gear"
+        }
+    }
+}
+
+struct ContentView: View {
+    @EnvironmentObject var api: APIClient
+    @EnvironmentObject var backend: BackendManager
+    @State private var selection: NavItem = .cases
+    @State private var selectedCaseID: String? = nil
+
+    var body: some View {
+        HStack(spacing: 0) {
+            // Column 1 — dark sidebar
+            SidebarView(selection: $selection)
+                .frame(width: 220)
+
+            Divider()
+
+            // Column 2 — case list (only for Cases tab)
+            if selection == .cases {
+                CaseListColumn(selectedCaseID: $selectedCaseID)
+                    .frame(width: 300)
+                Divider()
+            }
+
+            // Column 3 — detail / content area
+            Group {
+                switch selection {
+                case .cases:
+                    if let id = selectedCaseID {
+                        CaseDetailView(caseID: id)
+                            .id(id)
+                    } else {
+                        EmptyStateView(
+                            icon: "folder.open",
+                            title: "Select a Case",
+                            subtitle: "Pick a case from the list to view details, documents, and AI analysis."
+                        )
+                    }
+                case .agent:
+                    AgentView()
+                case .jobs:
+                    JobsView()
+                case .settings:
+                    SettingsView()
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(AF.Color.detailBg)
+        }
+        .frame(minWidth: 900, minHeight: 600)
+        .alert("Backend Error", isPresented: .constant(backend.startError != nil)) {
+            Button("OK") { backend.startError = nil }
+        } message: {
+            Text(backend.startError ?? "")
+        }
+    }
+}
+
+// MARK: - Sidebar
+
+struct SidebarView: View {
+    @Binding var selection: NavItem
+    @EnvironmentObject var api: APIClient
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // App header
+            HStack(spacing: AF.Spacing.sm) {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .fill(AF.Color.accent)
+                        .frame(width: 30, height: 30)
+                    Image(systemName: "scalemass.fill")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(.white)
+                }
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("AgentFlow")
+                        .font(.system(size: 14, weight: .bold))
+                        .foregroundStyle(AF.Color.sidebarText)
+                    Text("Legal AI Platform")
+                        .font(.system(size: 10))
+                        .foregroundStyle(AF.Color.sidebarTextSub)
+                }
+                Spacer()
+            }
+            .padding(.horizontal, AF.Spacing.md)
+            .padding(.top, AF.Spacing.lg)
+            .padding(.bottom, AF.Spacing.md)
+
+            Rectangle()
+                .fill(AF.Color.sidebarDivider)
+                .frame(height: 1)
+                .padding(.horizontal, AF.Spacing.md)
+
+            // Nav items
+            VStack(spacing: 2) {
+                ForEach(NavItem.allCases) { item in
+                    SidebarRow(item: item, isSelected: selection == item)
+                        .onTapGesture {
+                            withAnimation(.spring(duration: 0.2)) { selection = item }
+                        }
+                }
+            }
+            .padding(.horizontal, AF.Spacing.sm)
+            .padding(.top, AF.Spacing.sm)
+
+            Spacer()
+
+            // Bottom status
+            VStack(spacing: AF.Spacing.sm) {
+                Rectangle()
+                    .fill(AF.Color.sidebarDivider)
+                    .frame(height: 1)
+
+                HStack(spacing: AF.Spacing.sm) {
+                    ConnectionDot(connected: api.connected)
+                    Spacer()
+                    if let rag = api.ragSummary {
+                        HStack(spacing: 4) {
+                            Image(systemName: "doc.text.magnifyingglass")
+                                .font(.system(size: 10))
+                                .foregroundStyle(AF.Color.sidebarTextSub)
+                            Text("\(rag.documentCount) docs")
+                                .font(.system(size: 10, weight: .medium))
+                                .foregroundStyle(AF.Color.sidebarTextSub)
+                        }
+                    }
+                }
+                .padding(.horizontal, AF.Spacing.md)
+                .padding(.bottom, AF.Spacing.md)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(AF.Color.sidebarBg)
+    }
+}
+
+struct SidebarRow: View {
+    var item: NavItem
+    var isSelected: Bool
+
+    var body: some View {
+        HStack(spacing: 0) {
+            RoundedRectangle(cornerRadius: 1.5, style: .continuous)
+                .fill(isSelected ? AF.Color.accent : Color.clear)
+                .frame(width: 3)
+
+            HStack(spacing: AF.Spacing.sm) {
+                Image(systemName: item.icon)
+                    .font(.system(size: 13, weight: .medium))
+                    .frame(width: 18)
+                    .foregroundStyle(isSelected ? AF.Color.accent : AF.Color.sidebarTextSub)
+                Text(item.rawValue)
+                    .font(.system(size: 13, weight: isSelected ? .semibold : .regular))
+                    .foregroundStyle(isSelected ? AF.Color.sidebarText : AF.Color.sidebarTextSub)
+                Spacer()
+            }
+            .padding(.leading, AF.Spacing.sm)
+            .padding(.trailing, AF.Spacing.sm)
+            .padding(.vertical, 9)
+            .background(
+                isSelected ? AF.Color.sidebarSelected : Color.clear,
+                in: RoundedRectangle(cornerRadius: AF.Radius.chip, style: .continuous)
+            )
+        }
+        .contentShape(Rectangle())
+        .accessibilityLabel(item.rawValue)
+        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+    }
+}
+
+// MARK: - Jobs View
+
+struct JobsView: View {
+    @EnvironmentObject var api: APIClient
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("Background Jobs")
+                    .font(.system(size: 15, weight: .bold))
+                Spacer()
+                Text("\(api.jobs.count) active")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.horizontal, AF.Spacing.md)
+            .padding(.top, AF.Spacing.md)
+
+            ZStack {
+                if api.jobs.isEmpty {
+                    EmptyStateView(icon: "square.stack.3d.up", title: "No Active Jobs", subtitle: "Upload documents or run the agent to see background tasks here.")
+                } else {
+                    ScrollView {
+                        LazyVStack(spacing: AF.Spacing.sm) {
+                            ForEach(api.jobs.sorted(by: { $0.createdAt > $1.createdAt })) { job in
+                                JobRow(job: job)
+                            }
+                        }
+                        .padding(AF.Spacing.md)
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+}
+
+struct JobRow: View {
+    var job: AFJob
+
+    private var statusColor: Color {
+        switch job.status {
+        case "completed":  return AF.Color.accentGreen
+        case "failed":     return AF.Color.accentRed
+        case "processing": return AF.Color.accent
+        default:           return .secondary
+        }
+    }
+
+    var body: some View {
+        HStack(spacing: AF.Spacing.md) {
+            ProgressRing(progress: Double(job.progress) / 100.0, size: 36, color: statusColor)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(job.type.replacingOccurrences(of: "_", with: " ").capitalized)
+                    .font(.system(size: 13, weight: .semibold))
+                Text(job.error.isEmpty ? job.status : "Failed: \(job.error)")
+                    .font(.system(size: 11))
+                    .foregroundStyle(job.error.isEmpty ? .secondary : AF.Color.accentRed)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+
+            Text("\(job.progress)%")
+                .font(.system(size: 12, weight: .medium, design: .monospaced))
+                .foregroundStyle(statusColor)
+        }
+        .glassCard(padding: AF.Spacing.md)
+        .accessibilityLabel("\(job.type) job, \(job.status), \(job.progress) percent complete")
+    }
+}
+
+// MARK: - Settings View
+
+struct SettingsView: View {
+    @EnvironmentObject var api: APIClient
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: AF.Spacing.md) {
+                Text("Settings")
+                    .font(.system(size: 15, weight: .bold))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                VStack(alignment: .leading, spacing: AF.Spacing.sm) {
+                    SectionHeader(title: "Connection")
+                    HStack {
+                        Text("Backend URL")
+                            .font(.system(size: 13))
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Text(api.baseURL)
+                            .font(.system(size: 12, design: .monospaced))
+                            .foregroundStyle(.primary)
+                    }
+                    HStack {
+                        Text("Status")
+                            .font(.system(size: 13))
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        ConnectionDot(connected: api.connected)
+                    }
+                }
+                .glassCard()
+
+                if let rag = api.ragSummary {
+                    VStack(alignment: .leading, spacing: AF.Spacing.sm) {
+                        SectionHeader(title: "Knowledge Base")
+                        InfoRow(label: "Documents", value: "\(rag.documentCount)")
+                        InfoRow(label: "Chunks", value: "\(rag.totalChunks)")
+                        InfoRow(label: "Backend", value: rag.backendMode.uppercased())
+                    }
+                    .glassCard()
+                }
+
+                VStack(alignment: .leading, spacing: AF.Spacing.sm) {
+                    SectionHeader(title: "System")
+                    InfoRow(label: "Platform", value: "macOS \(ProcessInfo.processInfo.operatingSystemVersionString)")
+                    InfoRow(label: "App Version", value: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "dev")
+                }
+                .glassCard()
+            }
+            .padding(AF.Spacing.md)
+        }
+    }
+}
+
+struct InfoRow: View {
+    var label: String
+    var value: String
+
+    var body: some View {
+        HStack {
+            Text(label).font(.system(size: 13)).foregroundStyle(.secondary)
+            Spacer()
+            Text(value).font(.system(size: 13, weight: .medium)).foregroundStyle(.primary)
+        }
+    }
+}

--- a/agentflow/frontend/index.html
+++ b/agentflow/frontend/index.html
@@ -1,0 +1,1399 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>AgentFlow</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+/* ============================================================
+   AgentFlow Design System v1
+   Tokens → Primitives → Components
+   ============================================================ */
+
+:root{
+  /* ---- Color: foreground ---- */
+  --fg:#ffffff;
+  --fg-dim:#e6e9f2;
+  --fg-muted:#b8bdcc;
+  --fg-faint:#7a8094;
+
+  /* ---- Color: intent ---- */
+  --intent-primary:#7aa2ff;
+  --intent-primary-2:#c48bff;
+  --intent-primary-ink:#0b1534;
+  --intent-success:#4ade80;
+  --intent-warn:#facc15;
+  --intent-danger:#f87171;
+
+  /* ---- Surfaces (3-step elevation over glass) ---- */
+  --surface-0:transparent;
+  --surface-1:rgba(255,255,255,0.05);
+  --surface-2:rgba(255,255,255,0.09);
+  --surface-3:rgba(255,255,255,0.14);
+  --surface-sunken:rgba(0,0,0,0.25);
+  --surface-tint:rgba(20,22,30,0.45);
+
+  /* ---- Strokes ---- */
+  --stroke:rgba(255,255,255,0.12);
+  --stroke-strong:rgba(255,255,255,0.20);
+  --divider:rgba(255,255,255,0.10);
+
+  /* ---- Spacing scale (multiples of 4) ---- */
+  --space-1:4px;  --space-2:8px;  --space-3:12px; --space-4:16px;
+  --space-5:20px; --space-6:24px; --space-8:32px; --space-10:40px;
+  --space-12:48px;
+
+  /* ---- Radii (3 tokens) ---- */
+  --radius-sm:8px;
+  --radius-md:14px;
+  --radius-lg:20px;
+  --radius-pill:999px;
+
+  /* ---- Typography ---- */
+  --font-sans:-apple-system,BlinkMacSystemFont,'SF Pro Text','Inter',sans-serif;
+  --font-mono:'SF Mono','Menlo','Cascadia Code',monospace;
+  --text-xs:11px;  --text-sm:12.5px; --text-md:14px;
+  --text-lg:16px;  --text-xl:20px;   --text-2xl:24px;
+  --leading-tight:1.3;
+  --leading-body:1.55;
+
+  /* ---- Motion ---- */
+  --ease-standard:cubic-bezier(0.2, 0, 0, 1);
+  --ease-emphasized:cubic-bezier(0.3, 0, 0, 1);
+  --dur-quick:120ms;
+  --dur-base:200ms;
+  --dur-slow:320ms;
+
+  /* ---- Elevation (shadow scale) ---- */
+  --elev-1:0 1px 0 rgba(255,255,255,0.06) inset;
+  --elev-2:0 4px 16px rgba(0,0,0,0.18);
+  --elev-3:0 10px 40px rgba(0,0,0,0.35);
+}
+
+*{box-sizing:border-box}
+html,body{height:100%;margin:0}
+body{
+  font-family:var(--font-sans);
+  font-size:var(--text-md);
+  color:var(--fg);
+  background:linear-gradient(160deg, rgba(22,24,38,0.78), rgba(14,16,26,0.82));
+  -webkit-font-smoothing:antialiased;
+  overflow:hidden;
+}
+
+/* ============================================================
+   Layout
+   ============================================================ */
+.app{display:grid;grid-template-columns:240px 1fr;height:100vh}
+.titlebar-spacer{-webkit-app-region:drag;height:38px}
+
+/* ============================================================
+   Sidebar
+   ============================================================ */
+.sidebar{
+  display:flex;flex-direction:column;
+  padding:0 var(--space-3) var(--space-4);gap:var(--space-1);
+  border-right:1px solid var(--divider);
+  background:rgba(255,255,255,0.015);
+}
+.brand{display:flex;align-items:center;gap:var(--space-3);padding:var(--space-1) var(--space-3) var(--space-4)}
+.brand .logo{
+  width:34px;height:34px;border-radius:10px;
+  background:conic-gradient(from 210deg,#7aa2ff,#c48bff,#50c8dc,#7aa2ff);
+  box-shadow:0 4px 16px rgba(122,162,255,0.45);position:relative;
+}
+.brand .logo::after{
+  content:"";position:absolute;inset:3px;border-radius:8px;
+  background:rgba(10,12,18,0.7);backdrop-filter:blur(6px);
+}
+.brand .logo svg{position:absolute;inset:0;margin:auto;z-index:2}
+.brand h1{font-size:var(--text-md);font-weight:600;letter-spacing:0.2px;margin:0}
+.brand .ver{font-size:var(--text-xs);color:var(--fg-muted)}
+
+.nav-group{
+  font-size:10px;text-transform:uppercase;letter-spacing:1.2px;
+  color:var(--fg-muted);padding:var(--space-5) var(--space-3) var(--space-2);
+}
+.nav-item{
+  display:flex;align-items:center;gap:var(--space-3);
+  padding:var(--space-2) var(--space-3);border-radius:11px;
+  color:var(--fg-dim);font-size:13.5px;font-weight:500;cursor:pointer;
+  transition:background var(--dur-quick) var(--ease-standard),
+             color var(--dur-quick) var(--ease-standard);
+  border:1px solid transparent;
+}
+.nav-item:hover{background:var(--surface-1);color:var(--fg)}
+.nav-item.active{
+  background:linear-gradient(135deg, rgba(122,162,255,0.22), rgba(196,139,255,0.18));
+  color:var(--fg);border-color:rgba(255,255,255,0.14);
+  box-shadow:0 4px 16px rgba(122,162,255,0.18), inset 0 1px 0 rgba(255,255,255,0.1);
+}
+.nav-item svg{width:16px;height:16px;opacity:0.85}
+.nav-item .badge{
+  margin-left:auto;font-size:10.5px;
+  background:var(--surface-2);border:1px solid var(--stroke);
+  padding:2px 7px;border-radius:var(--radius-pill);color:var(--fg-dim);
+}
+.kbd{
+  font-family:var(--font-mono);font-size:10.5px;
+  padding:2px 6px;border-radius:5px;
+  background:rgba(0,0,0,0.30);border:1px solid var(--stroke);
+  color:var(--fg-muted);
+}
+.sidebar-foot{margin-top:auto;padding:var(--space-3);display:flex;flex-direction:column;gap:var(--space-2);font-size:var(--text-xs);color:var(--fg-muted)}
+
+/* ============================================================
+   Status pill (intent: success/danger)
+   ============================================================ */
+.status-pill{
+  display:inline-flex;align-items:center;gap:6px;
+  padding:5px 10px;border-radius:var(--radius-pill);
+  font-size:var(--text-xs);font-weight:500;width:fit-content;
+  background:rgba(74,222,128,0.10);
+  border:1px solid rgba(74,222,128,0.3);
+  color:#86efac;
+}
+.status-pill .dot{width:6px;height:6px;border-radius:50%;background:var(--intent-success);box-shadow:0 0 8px var(--intent-success)}
+.status-pill[data-intent="danger"]{background:rgba(248,113,113,0.1);border-color:rgba(248,113,113,0.3);color:#fca5a5}
+.status-pill[data-intent="danger"] .dot{background:var(--intent-danger);box-shadow:0 0 8px var(--intent-danger)}
+
+/* ============================================================
+   Main panel
+   ============================================================ */
+.main{display:flex;flex-direction:column;min-width:0;overflow:hidden}
+.view{display:none;flex:1;flex-direction:column;min-height:0}
+.view.active{display:flex}
+.view-head{
+  display:flex;align-items:center;gap:var(--space-4);
+  padding:var(--space-3) var(--space-6) var(--space-4);
+  border-bottom:1px solid var(--divider);
+}
+.view-head h2{margin:0;font-size:var(--text-xl);font-weight:600;letter-spacing:-0.3px}
+.view-head .sub{color:var(--fg-muted);font-size:13px;margin-top:2px}
+.view-head .spacer{flex:1}
+
+/* ============================================================
+   Button — variants via data-intent + data-size
+   ============================================================ */
+.btn{
+  display:inline-flex;align-items:center;gap:7px;
+  padding:8px 14px;border-radius:10px;
+  background:var(--surface-2);border:1px solid var(--stroke);
+  color:var(--fg);font-size:13px;font-weight:500;cursor:pointer;
+  font-family:inherit;
+  transition:background var(--dur-quick) var(--ease-standard),
+             border-color var(--dur-quick) var(--ease-standard),
+             transform var(--dur-quick) var(--ease-standard);
+}
+.btn:hover{background:var(--surface-3);border-color:var(--stroke-strong)}
+.btn:active{transform:translateY(1px)}
+.btn[data-intent="primary"]{
+  background:linear-gradient(135deg,var(--intent-primary),var(--intent-primary-2));
+  border-color:transparent;color:var(--intent-primary-ink);font-weight:600;
+  box-shadow:0 4px 18px rgba(122,162,255,0.35);
+}
+.btn[data-intent="primary"]:hover{filter:brightness(1.08)}
+.btn[data-intent="ghost"]{background:transparent;border-color:transparent}
+.btn[data-intent="ghost"]:hover{background:var(--surface-1)}
+.btn[data-intent="danger"]{color:#fca5a5;border-color:rgba(248,113,113,0.3)}
+.btn[data-intent="danger"]:hover{background:rgba(248,113,113,0.15)}
+.btn[data-size="sm"]{padding:5px 10px;font-size:var(--text-sm)}
+.btn:disabled{opacity:0.5;cursor:not-allowed}
+.spinner{display:inline-block;width:10px;height:10px;margin-left:6px;border:2px solid currentColor;border-right-color:transparent;border-radius:50%;vertical-align:-1px;animation:spin .6s linear infinite}
+@keyframes spin{to{transform:rotate(360deg)}}
+
+/* ============================================================
+   Inputs
+   ============================================================ */
+.input, textarea, select{
+  width:100%;padding:10px 13px;border-radius:10px;
+  background:var(--surface-sunken);border:1px solid var(--stroke);
+  color:var(--fg);font-size:13.5px;font-family:inherit;
+  outline:none;
+  transition:border-color var(--dur-quick) var(--ease-standard),
+             background var(--dur-quick) var(--ease-standard);
+}
+.input:focus, textarea:focus, select:focus{
+  border-color:var(--intent-primary);background:rgba(0,0,0,0.35);
+}
+textarea{resize:none;min-height:48px;line-height:var(--leading-body)}
+
+/* ============================================================
+   Chip (toggleable + filter)
+   ============================================================ */
+.chip{
+  display:inline-flex;align-items:center;gap:6px;
+  padding:5px 12px;border-radius:var(--radius-pill);
+  background:var(--surface-1);border:1px solid var(--stroke);
+  cursor:pointer;font-size:var(--text-sm);user-select:none;
+  transition:background var(--dur-quick) var(--ease-standard);
+}
+.chip:hover{background:var(--surface-2)}
+.chip.on{background:rgba(122,162,255,0.22);border-color:rgba(122,162,255,0.42);color:var(--fg)}
+.chip input{display:none}
+
+/* ============================================================
+   State-chip — intent variants
+   ============================================================ */
+.state-chip{
+  font-size:10.5px;font-weight:600;padding:3px 9px;border-radius:var(--radius-pill);
+  background:rgba(122,162,255,0.15);border:1px solid rgba(122,162,255,0.3);color:#c8d7ff;
+  text-transform:uppercase;letter-spacing:0.5px;
+}
+.state-chip[data-intent="success"]{background:rgba(74,222,128,0.12);border-color:rgba(74,222,128,0.3);color:#86efac}
+.state-chip[data-intent="warn"]{background:rgba(250,204,21,0.12);border-color:rgba(250,204,21,0.3);color:#fde68a}
+.state-chip[data-intent="danger"]{background:rgba(248,113,113,0.12);border-color:rgba(248,113,113,0.3);color:#fca5a5}
+
+/* ============================================================
+   Card / Panel
+   ============================================================ */
+.card{
+  background:var(--surface-1);border:1px solid var(--stroke);
+  border-radius:var(--radius-md);padding:var(--space-4);margin-bottom:var(--space-3);
+  backdrop-filter:blur(20px) saturate(160%);
+  -webkit-backdrop-filter:blur(20px) saturate(160%);
+  transition:background var(--dur-quick) var(--ease-standard),
+             border-color var(--dur-quick) var(--ease-standard);
+}
+.card:hover{background:var(--surface-2);border-color:var(--stroke-strong)}
+.card .row{display:flex;align-items:center;gap:var(--space-3)}
+.card .title{font-size:var(--text-md);font-weight:600}
+.card .meta{font-size:var(--text-sm);color:var(--fg-muted);margin-top:3px}
+.card .actions{margin-left:auto;display:flex;gap:6px}
+
+/* ============================================================
+   Stat card
+   ============================================================ */
+.grid-stat{display:grid;grid-template-columns:repeat(4,1fr);gap:var(--space-3);margin-bottom:var(--space-5)}
+.stat{
+  padding:var(--space-4);border-radius:var(--radius-md);
+  background:var(--surface-1);border:1px solid var(--stroke);
+}
+.stat .lbl{font-size:var(--text-xs);color:var(--fg-muted);text-transform:uppercase;letter-spacing:1px;margin-bottom:6px}
+.stat .val{font-size:var(--text-2xl);font-weight:600;letter-spacing:-0.5px}
+
+/* ============================================================
+   Tabs
+   ============================================================ */
+.tabs{display:flex;gap:var(--space-1);padding:0 var(--space-6);border-bottom:1px solid var(--divider)}
+.tab{
+  padding:10px 14px;font-size:13.5px;color:var(--fg-muted);
+  cursor:pointer;border-bottom:2px solid transparent;margin-bottom:-1px;
+  transition:color var(--dur-quick) var(--ease-standard);
+}
+.tab:hover{color:var(--fg-dim)}
+.tab.active{color:var(--fg);border-bottom-color:var(--intent-primary)}
+
+/* ============================================================
+   Empty state
+   ============================================================ */
+.empty{
+  display:flex;flex-direction:column;align-items:center;justify-content:center;
+  padding:var(--space-12) var(--space-6);text-align:center;color:var(--fg-muted);
+  gap:var(--space-3);
+}
+.empty .icon{
+  width:56px;height:56px;border-radius:18px;
+  background:var(--surface-1);border:1px solid var(--stroke);
+  display:flex;align-items:center;justify-content:center;
+}
+.empty h4{font-size:var(--text-lg);color:var(--fg);margin:0;font-weight:600}
+.empty p{font-size:var(--text-sm);max-width:340px;line-height:var(--leading-body);margin:0}
+.empty .actions{display:flex;gap:var(--space-2);margin-top:var(--space-2)}
+
+/* ============================================================
+   Skeleton loader
+   ============================================================ */
+.skel{
+  border-radius:var(--radius-sm);
+  background:linear-gradient(90deg,var(--surface-1) 0%,var(--surface-2) 50%,var(--surface-1) 100%);
+  background-size:200% 100%;animation:shimmer 1.4s infinite;
+}
+@keyframes shimmer{from{background-position:200% 0}to{background-position:-200% 0}}
+.skel.line{height:12px;margin:6px 0}
+.skel.line.short{width:40%}
+.skel.line.med{width:65%}
+.skel.card{height:74px;margin-bottom:var(--space-3)}
+
+/* ============================================================
+   Chat
+   ============================================================ */
+.chat-body{flex:1;display:flex;flex-direction:column;margin:0 var(--space-5) var(--space-5);min-height:0}
+.chat-main{
+  flex:1;overflow-y:auto;padding:var(--space-5) var(--space-8);
+  display:flex;flex-direction:column;gap:var(--space-4);scroll-behavior:smooth;
+}
+.chat-main::-webkit-scrollbar{width:8px}
+.chat-main::-webkit-scrollbar-thumb{background:var(--surface-2);border-radius:4px}
+
+.msg{display:flex;gap:var(--space-3);max-width:85%;animation:fadeUp var(--dur-slow) var(--ease-standard)}
+@keyframes fadeUp{from{opacity:0;transform:translateY(8px)}to{opacity:1;transform:none}}
+.msg .avatar{
+  width:30px;height:30px;border-radius:10px;flex-shrink:0;
+  display:flex;align-items:center;justify-content:center;
+  font-size:var(--text-sm);font-weight:700;
+}
+.msg.user{align-self:flex-end;flex-direction:row-reverse}
+.msg.user .avatar{background:linear-gradient(135deg,var(--intent-primary),var(--intent-primary-2));color:var(--intent-primary-ink)}
+.msg.bot .avatar{background:var(--surface-2);border:1px solid var(--stroke)}
+.msg .bubble{
+  padding:11px 15px;border-radius:var(--radius-md);
+  font-size:var(--text-md);line-height:var(--leading-body);
+  background:var(--surface-1);border:1px solid var(--stroke);
+  backdrop-filter:blur(20px) saturate(160%);
+  -webkit-backdrop-filter:blur(20px) saturate(160%);
+  white-space:pre-wrap;word-wrap:break-word;
+}
+.msg.user .bubble{
+  background:linear-gradient(135deg,rgba(122,162,255,0.3),rgba(196,139,255,0.25));
+  border-color:rgba(122,162,255,0.4);
+}
+.msg .bubble code{background:rgba(0,0,0,0.35);padding:1px 6px;border-radius:5px;font-size:12.5px;font-family:var(--font-mono)}
+.msg .bubble pre{background:rgba(0,0,0,0.4);padding:10px 12px;border-radius:9px;overflow-x:auto;font-family:var(--font-mono);font-size:12.5px;margin:8px 0}
+
+.msg .actions-row{
+  display:flex;gap:6px;margin-top:6px;
+  opacity:0;transition:opacity var(--dur-quick) var(--ease-standard);
+}
+.msg:hover .actions-row{opacity:1}
+.msg .icon-btn{
+  width:24px;height:24px;border-radius:7px;
+  display:flex;align-items:center;justify-content:center;
+  background:transparent;border:1px solid transparent;
+  color:var(--fg-muted);cursor:pointer;
+}
+.msg .icon-btn:hover{background:var(--surface-2);color:var(--fg);border-color:var(--stroke)}
+
+/* ---- CitationChip ---- */
+.citations{margin-top:var(--space-2);display:flex;flex-wrap:wrap;gap:6px}
+.citation{
+  display:inline-flex;align-items:center;gap:6px;
+  padding:4px 10px;border-radius:var(--radius-pill);
+  background:var(--surface-2);border:1px solid var(--stroke);
+  color:var(--fg-dim);font-size:var(--text-xs);
+  cursor:pointer;
+  transition:background var(--dur-quick) var(--ease-standard),
+             border-color var(--dur-quick) var(--ease-standard);
+}
+.citation:hover{background:var(--surface-3);border-color:var(--stroke-strong)}
+.citation .num{
+  display:inline-flex;align-items:center;justify-content:center;
+  width:16px;height:16px;border-radius:50%;
+  background:rgba(122,162,255,0.30);color:var(--fg);
+  font-size:9px;font-weight:700;
+}
+
+.typing{display:inline-flex;gap:4px;padding:4px 0}
+.typing span{width:6px;height:6px;border-radius:50%;background:var(--fg-muted);animation:typing 1.2s infinite}
+.typing span:nth-child(2){animation-delay:0.15s}
+.typing span:nth-child(3){animation-delay:0.3s}
+@keyframes typing{0%,60%,100%{opacity:0.3;transform:translateY(0)}30%{opacity:1;transform:translateY(-3px)}}
+
+.chat-compose{
+  padding:10px 12px;border-radius:var(--radius-md);
+  background:var(--surface-2);border:1px solid var(--stroke);
+  backdrop-filter:blur(30px) saturate(180%);
+  -webkit-backdrop-filter:blur(30px) saturate(180%);
+  display:flex;gap:var(--space-3);align-items:flex-end;
+  box-shadow:var(--elev-1);
+}
+.chat-compose textarea{flex:1;background:transparent;border:none;padding:8px 4px;min-height:24px;max-height:180px}
+.chat-compose textarea:focus{background:transparent}
+.chat-opts{display:flex;gap:var(--space-2);align-items:center;padding:0 var(--space-1) var(--space-2);color:var(--fg-muted);font-size:var(--text-sm)}
+
+/* ---- Hero (slimmer per critique) ---- */
+.hero{margin:auto;text-align:center;max-width:480px;padding:var(--space-10) var(--space-5)}
+.hero .orb{
+  width:48px;height:48px;margin:0 auto var(--space-3);border-radius:14px;
+  background:conic-gradient(from 210deg,var(--intent-primary),var(--intent-primary-2),#50c8dc,var(--intent-primary));
+  box-shadow:0 8px 30px rgba(122,162,255,0.4);
+}
+.hero h3{font-size:var(--text-xl);margin:0 0 var(--space-2);font-weight:600}
+.hero p{color:var(--fg-muted);font-size:13.5px;line-height:var(--leading-body);margin:0 0 var(--space-5)}
+.hero .starters{display:flex;flex-wrap:wrap;gap:var(--space-2);justify-content:center}
+
+/* ============================================================
+   Scroll containers
+   ============================================================ */
+.scroll{flex:1;overflow-y:auto;padding:0 var(--space-6) var(--space-6)}
+.scroll::-webkit-scrollbar{width:8px}
+.scroll::-webkit-scrollbar-thumb{background:var(--surface-2);border-radius:4px}
+
+/* ============================================================
+   Settings
+   ============================================================ */
+.settings-grid{max-width:720px;padding:var(--space-2)}
+.settings-grid .group{margin-bottom:var(--space-6)}
+.settings-grid .group h3{font-size:var(--text-md);margin:0 0 var(--space-3);font-weight:600;color:var(--fg)}
+
+/* ============================================================
+   Toast
+   ============================================================ */
+.toast{
+  position:fixed;bottom:var(--space-6);left:50%;transform:translateX(-50%);
+  padding:10px 20px;border-radius:var(--radius-md);
+  background:rgba(20,20,30,0.92);backdrop-filter:blur(20px);
+  border:1px solid var(--stroke);font-size:var(--text-md);z-index:200;
+  box-shadow:var(--elev-3);
+  animation:toastIn var(--dur-slow) var(--ease-emphasized);
+}
+@keyframes toastIn{from{opacity:0;transform:translate(-50%,10px)}to{opacity:1;transform:translateX(-50%)}}
+.toast[data-intent="danger"]{border-color:rgba(248,113,113,0.4);color:#fca5a5}
+.toast[data-intent="success"]{border-color:rgba(74,222,128,0.4);color:#86efac}
+
+/* ============================================================
+   Drop zone
+   ============================================================ */
+.drop{
+  border:1.5px dashed var(--stroke);border-radius:var(--radius-md);
+  padding:var(--space-8);text-align:center;color:var(--fg-muted);
+  cursor:pointer;margin-bottom:var(--space-3);
+  transition:border-color var(--dur-base) var(--ease-standard),
+             background var(--dur-base) var(--ease-standard);
+}
+.drop:hover, .drop.drag{border-color:var(--intent-primary);background:rgba(122,162,255,0.06);color:var(--fg)}
+
+/* ============================================================
+   Command Palette (⌘K)
+   ============================================================ */
+.cmdk-backdrop{
+  position:fixed;inset:0;z-index:300;
+  background:rgba(0,0,0,0.30);backdrop-filter:blur(8px);
+  display:flex;align-items:flex-start;justify-content:center;
+  padding-top:14vh;
+  animation:fadeIn var(--dur-base) var(--ease-standard);
+}
+@keyframes fadeIn{from{opacity:0}to{opacity:1}}
+.cmdk{
+  width:min(620px, 90vw);
+  background:rgba(28,30,42,0.92);backdrop-filter:blur(40px) saturate(180%);
+  border:1px solid var(--stroke-strong);border-radius:var(--radius-lg);
+  box-shadow:var(--elev-3);overflow:hidden;
+  animation:cmdkIn var(--dur-base) var(--ease-emphasized);
+}
+@keyframes cmdkIn{from{opacity:0;transform:translateY(-8px) scale(0.98)}to{opacity:1;transform:none}}
+.cmdk-input{
+  width:100%;padding:var(--space-4) var(--space-5);
+  background:transparent;border:none;border-bottom:1px solid var(--divider);
+  color:var(--fg);font-size:15px;font-family:inherit;outline:none;
+}
+.cmdk-input::placeholder{color:var(--fg-faint)}
+.cmdk-list{max-height:50vh;overflow-y:auto;padding:var(--space-2)}
+.cmdk-section{
+  font-size:10px;text-transform:uppercase;letter-spacing:1.2px;
+  color:var(--fg-muted);padding:var(--space-3) var(--space-3) var(--space-1);
+}
+.cmdk-item{
+  display:flex;align-items:center;gap:var(--space-3);
+  padding:9px 12px;border-radius:10px;cursor:pointer;
+  font-size:13.5px;color:var(--fg-dim);
+}
+.cmdk-item .ic{
+  width:24px;height:24px;border-radius:7px;
+  background:var(--surface-1);border:1px solid var(--stroke);
+  display:flex;align-items:center;justify-content:center;color:var(--fg-muted);
+}
+.cmdk-item .meta{margin-left:auto;font-size:var(--text-xs);color:var(--fg-faint)}
+.cmdk-item.active{background:linear-gradient(135deg,rgba(122,162,255,0.22),rgba(196,139,255,0.18));color:var(--fg)}
+.cmdk-item.active .ic{background:rgba(122,162,255,0.25);border-color:rgba(122,162,255,0.4);color:var(--fg)}
+.cmdk-empty{padding:var(--space-6);text-align:center;color:var(--fg-muted);font-size:var(--text-sm)}
+.cmdk-foot{
+  display:flex;gap:var(--space-3);padding:8px var(--space-4);
+  border-top:1px solid var(--divider);font-size:var(--text-xs);color:var(--fg-muted);
+}
+.cmdk-foot .kbd{background:rgba(0,0,0,0.3)}
+
+/* ============================================================
+   Modal (form dialogs, confirms)
+   ============================================================ */
+.modal-backdrop{
+  position:fixed;inset:0;z-index:400;
+  background:rgba(0,0,0,0.45);backdrop-filter:blur(8px);
+  display:flex;align-items:center;justify-content:center;
+  padding:var(--space-6);
+  animation:fadeIn var(--dur-base) var(--ease-standard);
+}
+.modal{
+  width:min(460px, 92vw);
+  background:rgba(28,30,42,0.92);backdrop-filter:blur(40px) saturate(180%);
+  -webkit-backdrop-filter:blur(40px) saturate(180%);
+  border:1px solid var(--stroke-strong);border-radius:var(--radius-lg);
+  box-shadow:var(--elev-3);overflow:hidden;
+  animation:cmdkIn var(--dur-base) var(--ease-emphasized);
+  display:flex;flex-direction:column;
+}
+.modal-head{padding:var(--space-5) var(--space-5) var(--space-2)}
+.modal-title{font-size:var(--text-lg);font-weight:600;color:var(--fg);margin:0}
+.modal-desc{font-size:var(--text-sm);color:var(--fg-muted);margin:var(--space-2) 0 0;line-height:var(--leading-body)}
+.modal-body{padding:var(--space-4) var(--space-5);display:flex;flex-direction:column;gap:var(--space-3)}
+.modal-field{display:flex;flex-direction:column;gap:6px}
+.modal-field label{font-size:var(--text-xs);text-transform:uppercase;letter-spacing:1px;color:var(--fg-muted)}
+.modal-foot{
+  display:flex;justify-content:flex-end;gap:var(--space-2);
+  padding:var(--space-3) var(--space-5) var(--space-5);
+  border-top:1px solid var(--divider);background:var(--surface-1);
+}
+</style>
+</head>
+<body>
+<div class="app">
+  <aside class="sidebar">
+    <div class="titlebar-spacer"></div>
+    <div class="brand">
+      <div class="logo">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none"><path d="M12 2L4 7v10l8 5 8-5V7l-8-5z" stroke="#fff" stroke-width="1.8" stroke-linejoin="round"/><path d="M12 12l8-5M12 12v10M12 12L4 7" stroke="#fff" stroke-width="1.5"/></svg>
+      </div>
+      <div><h1>AgentFlow</h1><div class="ver">v2 · Liquid</div></div>
+    </div>
+
+    <div class="nav-item" id="cmdk-trigger" title="Open command palette">
+      <svg viewBox="0 0 24 24" fill="none"><circle cx="11" cy="11" r="7" stroke="currentColor" stroke-width="1.8"/><path d="M21 21l-5-5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg>
+      Search & commands <span class="kbd" style="margin-left:auto">⌘K</span>
+    </div>
+
+    <div class="nav-group">Workspace</div>
+    <div class="nav-item active" data-view="chat">
+      <svg viewBox="0 0 24 24" fill="none"><path d="M21 12a9 9 0 11-3.2-6.9L21 3v6h-6" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      Chat <span class="badge">AI</span>
+    </div>
+    <div class="nav-item" data-view="cases">
+      <svg viewBox="0 0 24 24" fill="none"><path d="M4 7h16M4 12h16M4 17h10" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg>
+      Cases <span class="badge" id="nav-case-count">0</span>
+    </div>
+    <div class="nav-item" data-view="docs">
+      <svg viewBox="0 0 24 24" fill="none"><path d="M6 3h9l4 4v14a1 1 0 01-1 1H6a1 1 0 01-1-1V4a1 1 0 011-1z" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"/><path d="M14 3v5h5" stroke="currentColor" stroke-width="1.8"/></svg>
+      Documents <span class="badge" id="nav-doc-count">0</span>
+    </div>
+    <div class="nav-item" data-view="jobs">
+      <svg viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="1.8"/><path d="M12 7v5l3 2" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg>
+      Jobs <span class="badge" id="nav-job-count">0</span>
+    </div>
+    <div class="nav-group">System</div>
+    <div class="nav-item" data-view="settings">
+      <svg viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="3" stroke="currentColor" stroke-width="1.8"/><path d="M19.4 15a1.7 1.7 0 00.3 1.9 2 2 0 11-2.8 2.8 1.7 1.7 0 00-1.9-.3 1.7 1.7 0 00-1 1.5V21a2 2 0 01-4 0 1.7 1.7 0 00-1-1.5 1.7 1.7 0 00-1.9.3 2 2 0 11-2.8-2.8 1.7 1.7 0 00.3-1.9 1.7 1.7 0 00-1.5-1H3a2 2 0 010-4 1.7 1.7 0 001.5-1 1.7 1.7 0 00-.3-1.9 2 2 0 012.8-2.8 1.7 1.7 0 001.9.3h.1a1.7 1.7 0 001-1.5V3a2 2 0 014 0 1.7 1.7 0 001 1.5 1.7 1.7 0 001.9-.3 2 2 0 012.8 2.8 1.7 1.7 0 00-.3 1.9 1.7 1.7 0 001.5 1H21a2 2 0 010 4 1.7 1.7 0 00-1.5 1z" stroke="currentColor" stroke-width="1.5"/></svg>
+      Settings
+    </div>
+    <div class="sidebar-foot">
+      <div id="conn-pill" class="status-pill"><div class="dot"></div>Connecting…</div>
+      <div id="model-info">Model: —</div>
+    </div>
+  </aside>
+
+  <main class="main">
+    <div class="titlebar-spacer"></div>
+
+    <!-- ============== CHAT ============== -->
+    <section class="view active" data-view="chat">
+      <div class="view-head">
+        <div><h2>Chat</h2><div class="sub">Ground answers in case documents via RAG, or ask anything.</div></div>
+        <div class="spacer"></div>
+        <button class="btn" data-intent="ghost" data-size="sm" id="chat-clear" title="Clear conversation">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none"><path d="M3 6h18M8 6V4a1 1 0 011-1h6a1 1 0 011 1v2M19 6l-1 14a1 1 0 01-1 1H7a1 1 0 01-1-1L5 6" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/></svg>
+          Clear
+        </button>
+      </div>
+      <div class="chat-body">
+        <div id="chat-main" class="chat-main">
+          <div class="hero">
+            <div class="orb"></div>
+            <h3>Ask about a case</h3>
+            <p>Pick a case below to ground your answers, or just start typing. Citations appear inline so you can jump to source.</p>
+            <div class="starters">
+              <span class="chip" data-q="Summarize the most recent case and list next actions.">📋 Summarize latest case</span>
+              <span class="chip" data-q="What deadlines are coming up across all my cases?">⏰ Upcoming deadlines</span>
+              <span class="chip" data-q="What are the risks visible across my uploaded contracts?">⚠️ Risk scan</span>
+            </div>
+          </div>
+        </div>
+        <div class="chat-opts">
+          <label class="chip on" id="chip-rag"><input type="checkbox" checked> <span>📚 Ground in docs</span></label>
+          <select id="chat-case" class="chip" style="padding:5px 12px">
+            <option value="">No case context</option>
+          </select>
+          <div style="margin-left:auto;font-size:11px;color:var(--fg-muted)" id="chat-status"></div>
+        </div>
+        <div class="chat-compose">
+          <textarea id="chat-input" placeholder="Ask AgentFlow…  (⏎ to send, shift+⏎ for new line)" rows="1"></textarea>
+          <button class="btn" data-intent="primary" id="chat-send">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none"><path d="M4 12h16m0 0l-6-6m6 6l-6 6" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            Send
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============== CASES ============== -->
+    <section class="view" data-view="cases">
+      <div class="view-head">
+        <div><h2>Cases</h2><div class="sub">All active matters and workflow states.</div></div>
+        <div class="spacer"></div>
+        <button class="btn" id="case-refresh">Refresh</button>
+        <button class="btn" data-intent="primary" id="case-new">+ New Case</button>
+      </div>
+      <div class="scroll">
+        <div class="grid-stat" id="case-stats"></div>
+        <div id="case-list"></div>
+      </div>
+    </section>
+
+    <!-- ============== DOCS ============== -->
+    <section class="view" data-view="docs">
+      <div class="view-head">
+        <div><h2>Documents</h2><div class="sub">Upload, search via BM25 / RAG, and preview.</div></div>
+        <div class="spacer"></div>
+        <button class="btn" id="docs-refresh">Refresh</button>
+      </div>
+      <div class="scroll">
+        <div class="drop" id="drop">
+          <div style="font-size:15px;font-weight:600;margin-bottom:6px">Drop files or click to upload</div>
+          <div style="font-size:12px">PDF, TXT, DOCX. Batched upload supported.</div>
+          <input type="file" id="file-input" multiple style="display:none">
+        </div>
+        <div style="display:flex;gap:8px;margin-bottom:14px">
+          <input class="input" id="search-q" placeholder="Search across your documents (BM25/RAG)…" />
+          <button class="btn" data-intent="primary" id="search-go">Search</button>
+        </div>
+        <div id="doc-list"></div>
+      </div>
+    </section>
+
+    <!-- ============== JOBS ============== -->
+    <section class="view" data-view="jobs">
+      <div class="view-head">
+        <div><h2>Jobs</h2><div class="sub">Background processing, OCR, and LLM tasks (live via websocket).</div></div>
+        <div class="spacer"></div>
+        <button class="btn" id="jobs-refresh">Refresh</button>
+      </div>
+      <div class="scroll">
+        <div id="job-list"></div>
+      </div>
+    </section>
+
+    <!-- ============== SETTINGS ============== -->
+    <section class="view" data-view="settings">
+      <div class="view-head">
+        <div><h2>Settings</h2><div class="sub">Backend, model, and connection status.</div></div>
+      </div>
+      <div class="scroll">
+        <div class="settings-grid">
+          <div class="group">
+            <h3>Server</h3>
+            <div class="card">
+              <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:6px">
+                <div><div class="title">API endpoint</div><div class="meta" id="set-url"></div></div>
+                <span class="state-chip" data-intent="success" id="set-health">—</span>
+              </div>
+              <div id="set-meta" style="font-size:12px;color:var(--fg-muted);margin-top:10px"></div>
+            </div>
+          </div>
+          <div class="group">
+            <h3>Model</h3>
+            <div class="card" id="set-model"></div>
+          </div>
+          <div class="group">
+            <h3>About</h3>
+            <div class="card">
+              <div class="title" style="margin-bottom:4px">AgentFlow</div>
+              <div class="meta">macOS desktop app built on a Go server and a WKWebView shell. Liquid-glass UI. DashScope / Ollama / MLX backends.</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+  </main>
+</div>
+
+<script>
+/* ============================================================
+   AgentFlow App JS
+   ============================================================ */
+const API = '/v1';
+const state = { cases:[], docs:[], chat:[], chatBusy:false };
+
+const $ = (s,el=document)=>el.querySelector(s);
+const $$ = (s,el=document)=>Array.from(el.querySelectorAll(s));
+const esc = s => (s??'').toString().replace(/[&<>"']/g, m=>({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[m]));
+const fmtTime = iso => { try{ return new Date(iso).toLocaleString() }catch{ return iso } };
+
+function toast(msg, intent='success'){
+  const t = document.createElement('div');
+  t.className='toast'; t.dataset.intent=intent; t.textContent=msg;
+  document.body.appendChild(t);
+  setTimeout(()=>{t.style.opacity=0;t.style.transition='opacity .3s';setTimeout(()=>t.remove(),300)},2400);
+}
+async function apiRaw(url, opts={}){
+  const res = await fetch(url, {headers:{'Content-Type':'application/json',...(opts.headers||{})}, ...opts});
+  const text = await res.text(); let data=null;
+  try{ data = text? JSON.parse(text):null }catch{ data = text }
+  if(!res.ok) throw new Error((data&&data.error)||res.statusText);
+  return data;
+}
+async function api(path, opts={}){ return apiRaw(API + path, opts); }
+async function bareFetch(path, opts={}){ return apiRaw(path, opts); }
+
+async function withBusy(btn, fn){
+  if(!btn || btn.disabled) return;
+  btn.disabled = true;
+  const spin = document.createElement('span'); spin.className='spinner';
+  btn.appendChild(spin);
+  try{ return await fn(); }
+  finally{ spin.remove(); btn.disabled = false; }
+}
+
+/* ---------- EmptyState renderer ---------- */
+function emptyState({icon='📂', title, body, actionLabel, onAction}){
+  const wrap = document.createElement('div');
+  wrap.className = 'empty';
+  wrap.innerHTML = `
+    <div class="icon" style="font-size:24px">${icon}</div>
+    <h4>${esc(title)}</h4>
+    <p>${esc(body)}</p>
+    ${actionLabel?`<div class="actions"><button class="btn" data-intent="primary">${esc(actionLabel)}</button></div>`:''}
+  `;
+  if(actionLabel && onAction) wrap.querySelector('button').addEventListener('click', onAction);
+  return wrap;
+}
+
+/* ---------- Modal helper ----------
+   openModal({title, description, fields, submitLabel, cancelLabel, intent, onSubmit})
+     - fields: [{name, label, placeholder, value, required}]  (omit for confirm dialogs)
+     - onSubmit(values) may return a Promise; throw/reject keeps the modal open.
+   Returns a Promise that resolves with the submitted values (or null if cancelled).
+   Features: backdrop click closes, Escape closes, focus trap, Enter submits. */
+function openModal({title, description, fields=[], submitLabel='Confirm', cancelLabel='Cancel', intent='primary', onSubmit}={}){
+  return new Promise(resolve=>{
+    const prevFocus = document.activeElement;
+    const backdrop = document.createElement('div');
+    backdrop.className = 'modal-backdrop';
+    const fieldsHtml = fields.map((f,i)=>`
+      <div class="modal-field">
+        <label for="modal-f-${i}">${esc(f.label||f.name)}</label>
+        <input class="input" id="modal-f-${i}" name="${esc(f.name)}"
+          placeholder="${esc(f.placeholder||'')}" value="${esc(f.value||'')}"
+          ${f.required?'required':''} autocomplete="off" />
+      </div>`).join('');
+    backdrop.innerHTML = `
+      <div class="modal" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+        <form class="modal-form" novalidate>
+          <div class="modal-head">
+            <h3 class="modal-title" id="modal-title">${esc(title||'')}</h3>
+            ${description?`<p class="modal-desc">${esc(description)}</p>`:''}
+          </div>
+          ${fields.length?`<div class="modal-body">${fieldsHtml}</div>`:''}
+          <div class="modal-foot">
+            <button type="button" class="btn" data-intent="ghost" data-modal-cancel>${esc(cancelLabel)}</button>
+            <button type="submit" class="btn" data-intent="${esc(intent)}" data-modal-submit>${esc(submitLabel)}</button>
+          </div>
+        </form>
+      </div>`;
+    document.body.appendChild(backdrop);
+
+    const modal = backdrop.querySelector('.modal');
+    const form = backdrop.querySelector('form');
+    const submitBtn = backdrop.querySelector('[data-modal-submit]');
+    let settled = false;
+
+    function close(result){
+      if(settled) return;
+      settled = true;
+      backdrop.remove();
+      document.removeEventListener('keydown', onKey, true);
+      if(prevFocus && prevFocus.focus) try{ prevFocus.focus() }catch{}
+      resolve(result);
+    }
+    function focusable(){
+      return Array.from(modal.querySelectorAll(
+        'input,button,textarea,select,[tabindex]:not([tabindex="-1"])'
+      )).filter(el=>!el.disabled && el.offsetParent!==null);
+    }
+    function onKey(e){
+      if(e.key==='Escape'){ e.preventDefault(); close(null); return; }
+      if(e.key==='Tab'){
+        const items = focusable();
+        if(!items.length) return;
+        const first = items[0], last = items[items.length-1];
+        if(e.shiftKey && document.activeElement===first){ e.preventDefault(); last.focus(); }
+        else if(!e.shiftKey && document.activeElement===last){ e.preventDefault(); first.focus(); }
+      }
+    }
+    document.addEventListener('keydown', onKey, true);
+    backdrop.addEventListener('mousedown', e=>{ if(e.target===backdrop) close(null); });
+    backdrop.querySelector('[data-modal-cancel]').addEventListener('click', ()=>close(null));
+
+    form.addEventListener('submit', async e=>{
+      e.preventDefault();
+      const values = {};
+      for(const f of fields){
+        const el = form.querySelector(`[name="${f.name}"]`);
+        values[f.name] = (el?.value||'').trim();
+        if(f.required && !values[f.name]){ el.focus(); return; }
+      }
+      if(onSubmit){
+        submitBtn.disabled = true;
+        try{ await onSubmit(values); }
+        catch(err){ submitBtn.disabled = false; return; } // keep modal open on failure
+      }
+      close(values);
+    });
+
+    // Initial focus: first field, else submit button
+    setTimeout(()=>{
+      const first = modal.querySelector('input') || submitBtn;
+      first?.focus();
+      if(first?.select) try{ first.select() }catch{}
+    }, 0);
+  });
+}
+
+/* ---------- Skeleton helpers ---------- */
+function skelCards(n=3){
+  return Array.from({length:n}, ()=>'<div class="skel card"></div>').join('');
+}
+function skelLines(){
+  return `<div class="skel line med"></div><div class="skel line"></div><div class="skel line short"></div>`;
+}
+
+/* ---------- View switching ---------- */
+function gotoView(v){
+  $$('.nav-item[data-view]').forEach(x=>x.classList.toggle('active', x.dataset.view===v));
+  $$('.view').forEach(x=>x.classList.toggle('active', x.dataset.view===v));
+  if(v==='cases') loadCases();
+  if(v==='docs') loadDocs();
+  if(v==='jobs') loadJobs();
+  if(v==='settings') loadSettings();
+}
+$$('.nav-item[data-view]').forEach(n=>n.addEventListener('click', ()=>gotoView(n.dataset.view)));
+
+/* ============================================================
+   Chat with citations
+   ============================================================ */
+const chatMain = $('#chat-main');
+const chatInput = $('#chat-input');
+const chatCase = $('#chat-case');
+const ragChip = $('#chip-rag');
+ragChip.addEventListener('click', e=>{
+  if(e.target.tagName==='INPUT') return;
+  const cb = ragChip.querySelector('input'); cb.checked = !cb.checked;
+  ragChip.classList.toggle('on', cb.checked);
+});
+
+function renderBubbleHTML(content){
+  let b = esc(content);
+  b = b.replace(/```([\s\S]*?)```/g,(_,c)=>`<pre>${c}</pre>`);
+  b = b.replace(/`([^`]+)`/g,'<code>$1</code>');
+  b = b.replace(/\*\*([^*]+)\*\*/g,'<b>$1</b>');
+  return b;
+}
+function appendMsg(m){
+  const hero = chatMain.querySelector('.hero'); if(hero) hero.remove();
+  const el = document.createElement('div');
+  el.className = `msg ${m.role==='bot'?'bot':'user'}`;
+  const av = m.role==='user'?'You':'AF';
+
+  let citations='';
+  if(m.sources && m.sources.length){
+    citations = `<div class="citations">${m.sources.map((s,i)=>{
+      const fname = typeof s==='string' ? s : (s.filename || s.name || '');
+      const score = (s.score!=null) ? ` · ${(s.score*100|0)}%` : '';
+      return `<span class="citation" data-doc="${esc(fname)}" title="Open ${esc(fname)}">
+        <span class="num">${i+1}</span>📄 ${esc(fname)}<span style="color:var(--fg-faint)">${score}</span>
+      </span>`;
+    }).join('')}</div>`;
+  }
+
+  let actions='';
+  if(m.role==='bot' && m.content && !m.error){
+    actions = `<div class="actions-row">
+      <button class="icon-btn" data-act="copy" title="Copy">
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none"><rect x="8" y="8" width="12" height="12" rx="2" stroke="currentColor" stroke-width="1.7"/><path d="M16 8V5a1 1 0 00-1-1H5a1 1 0 00-1 1v10a1 1 0 001 1h3" stroke="currentColor" stroke-width="1.7"/></svg>
+      </button>
+      <button class="icon-btn" data-act="redo" title="Regenerate">
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none"><path d="M21 12a9 9 0 11-3.2-6.9L21 3v6h-6" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/></svg>
+      </button>
+    </div>`;
+  }
+
+  el.innerHTML = `<div class="avatar">${av}</div>
+    <div style="flex:1;min-width:0">
+      <div class="bubble">${renderBubbleHTML(m.content)}${citations}</div>
+      ${actions}
+    </div>`;
+
+  // Wire citation chips → open document in new tab
+  el.querySelectorAll('.citation').forEach(c=>{
+    c.addEventListener('click',()=>{
+      const f = c.dataset.doc; if(!f) return;
+      window.open(`${API}/documents/${encodeURIComponent(f)}/view`, '_blank');
+    });
+  });
+  // Wire copy / regenerate
+  el.querySelectorAll('[data-act="copy"]').forEach(b=>b.addEventListener('click',()=>{
+    navigator.clipboard.writeText(m.content); toast('Copied');
+  }));
+  el.querySelectorAll('[data-act="redo"]').forEach(b=>b.addEventListener('click',()=>{
+    // pop the last bot message and re-send the prior user prompt
+    const idx = state.chat.lastIndexOf(m);
+    if(idx > 0){
+      state.chat = state.chat.slice(0, idx);
+      el.remove();
+      const lastUser = [...state.chat].reverse().find(x=>x.role==='user');
+      if(lastUser){ chatInput.value = lastUser.content; sendChat(); }
+    }
+  }));
+
+  chatMain.appendChild(el);
+  chatMain.scrollTop = chatMain.scrollHeight;
+}
+function appendTyping(){
+  const el = document.createElement('div'); el.className='msg bot'; el.id='typing';
+  el.innerHTML = `<div class="avatar">AF</div><div class="bubble"><div class="typing"><span></span><span></span><span></span></div></div>`;
+  chatMain.appendChild(el); chatMain.scrollTop = chatMain.scrollHeight;
+}
+async function sendChat(){
+  const text = chatInput.value.trim(); if(!text || state.chatBusy) return;
+  const sendBtn = $('#chat-send');
+  state.chatBusy = true; sendBtn.disabled = true;
+  const spin = document.createElement('span'); spin.className='spinner'; sendBtn.appendChild(spin);
+  const msg = {role:'user', content:text};
+  state.chat.push(msg); appendMsg(msg);
+  chatInput.value=''; autoresize();
+  appendTyping();
+  try{
+    const body = {
+      messages: state.chat.map(m=>({role:m.role==='bot'?'assistant':m.role, content:m.content})),
+      case_id: chatCase.value || '',
+      use_rag: ragChip.querySelector('input').checked,
+    };
+    const r = await api('/chat', {method:'POST', body:JSON.stringify(body)});
+    $('#typing')?.remove();
+    const out = {role:'bot', content:r.reply || '(empty reply)', sources:r.sources||[]};
+    state.chat.push(out); appendMsg(out);
+  }catch(e){
+    $('#typing')?.remove();
+    const err = {role:'bot', content:`⚠️ ${e.message}`, error:true};
+    state.chat.push(err); appendMsg(err);
+  } finally{
+    state.chatBusy=false; spin.remove(); sendBtn.disabled=false; chatInput.focus();
+  }
+}
+$('#chat-send').addEventListener('click', sendChat);
+chatInput.addEventListener('keydown', e=>{
+  if(e.key==='Enter' && !e.shiftKey){ e.preventDefault(); sendChat(); }
+});
+function autoresize(){ chatInput.style.height='auto'; chatInput.style.height = Math.min(180, chatInput.scrollHeight)+'px'; }
+chatInput.addEventListener('input', autoresize);
+const chatHeroHTML = chatMain.innerHTML;
+$('#chat-clear').addEventListener('click', ()=>{
+  state.chat = [];
+  chatMain.innerHTML = chatHeroHTML;
+  chatMain.querySelectorAll('.starters .chip').forEach(s=>s.addEventListener('click', ()=>{
+    chatInput.value = s.dataset.q; autoresize(); sendChat();
+  }));
+});
+
+// Starter chips in hero
+chatMain.querySelectorAll('.starters .chip').forEach(s=>s.addEventListener('click', ()=>{
+  chatInput.value = s.dataset.q; autoresize(); sendChat();
+}));
+
+/* ============================================================
+   Cases
+   ============================================================ */
+async function loadCases(){
+  const list = $('#case-list');
+  list.innerHTML = skelCards(4);
+  try{
+    const data = await fetch(API+'/cases').then(r=>r.json());
+    state.cases = data.cases || data || [];
+    $('#nav-case-count').textContent = state.cases.length;
+    chatCase.innerHTML = '<option value="">No case context</option>' + state.cases.map(c=>`<option value="${esc(c.case_id)}">${esc(c.case_id)} · ${esc(c.client_name||'')}</option>`).join('');
+    renderCases();
+  }catch(e){ toast('Failed to load cases: '+e.message,'danger') }
+}
+function renderCases(){
+  const stats = $('#case-stats');
+  const byState = {};
+  for(const c of state.cases){ byState[c.state] = (byState[c.state]||0)+1 }
+  stats.innerHTML = `
+    <div class="stat"><div class="lbl">Total</div><div class="val">${state.cases.length}</div></div>
+    <div class="stat"><div class="lbl">Capture</div><div class="val">${byState.CLIENT_CAPTURE||0}</div></div>
+    <div class="stat"><div class="lbl">In Progress</div><div class="val">${(byState.INITIAL_CONTACT||0)+(byState.CASE_EVALUATION||0)}</div></div>
+    <div class="stat"><div class="lbl">Closed</div><div class="val">${byState.CLOSED||0}</div></div>`;
+  const list = $('#case-list');
+  if(!state.cases.length){
+    list.innerHTML = '';
+    list.appendChild(emptyState({
+      icon:'📁',
+      title:'No cases yet',
+      body:'Create your first matter to start grounding AI answers in client documents.',
+      actionLabel:'+ New Case',
+      onAction: ()=>$('#case-new').click(),
+    }));
+    return;
+  }
+  list.innerHTML = state.cases.map(c=>`
+    <div class="card">
+      <div class="row">
+        <div>
+          <div class="title">${esc(c.client_name||'—')} <span class="state-chip">${esc(c.state||'')}</span></div>
+          <div class="meta">${esc(c.case_id)} · ${esc(c.matter_type||'')} · ${fmtTime(c.updated_at)}</div>
+        </div>
+        <div class="actions">
+          <button class="btn" data-size="sm" data-chat="${esc(c.case_id)}">Ask AI</button>
+          <button class="btn" data-size="sm" data-advance="${esc(c.case_id)}">Advance →</button>
+          <button class="btn" data-size="sm" data-intent="danger" data-delete="${esc(c.case_id)}">Delete</button>
+        </div>
+      </div>
+    </div>`).join('');
+  list.querySelectorAll('[data-chat]').forEach(b=>b.addEventListener('click',()=>{
+    chatCase.value = b.dataset.chat;
+    chatInput.value = `Summarize case ${b.dataset.chat} and list next steps.`;
+    gotoView('chat');
+    sendChat();
+  }));
+  list.querySelectorAll('[data-advance]').forEach(b=>b.addEventListener('click', ()=>withBusy(b, async ()=>{
+    try{ await api(`/cases/${b.dataset.advance}/advance`,{method:'POST',body:'{}'}); toast('Advanced'); loadCases(); }
+    catch(e){ toast(e.message,'danger') }
+  })));
+  list.querySelectorAll('[data-delete]').forEach(b=>b.addEventListener('click', async ()=>{
+    const ok = await openModal({
+      title:'Delete case?',
+      description:`Case ${b.dataset.delete} will be permanently removed. This cannot be undone.`,
+      submitLabel:'Delete',
+      cancelLabel:'Cancel',
+      intent:'danger',
+    });
+    if(!ok) return;
+    withBusy(b, async ()=>{
+      try{ await api(`/cases/${b.dataset.delete}`,{method:'DELETE'}); toast('Deleted'); loadCases(); }
+      catch(e){ toast(e.message,'danger') }
+    });
+  }));
+}
+$('#case-refresh').addEventListener('click', loadCases);
+$('#case-new').addEventListener('click', ()=>{
+  openModal({
+    title:'New case',
+    description:'Create a new case. You can add documents and run the workflow afterwards.',
+    submitLabel:'Create case',
+    fields:[
+      {name:'client_name', label:'Client name', placeholder:'ClientX', value:'ClientX', required:true},
+      {name:'matter_type', label:'Matter type', placeholder:'Commercial Lease Dispute', value:'Commercial Lease Dispute', required:true},
+    ],
+    onSubmit: async values => {
+      try{
+        await api('/cases/create',{method:'POST',body:JSON.stringify({
+          client_name:values.client_name, matter_type:values.matter_type, source_channel:'UI',
+        })});
+        toast('Created'); loadCases();
+      }catch(e){ toast(e.message,'danger'); throw e; }
+    },
+  });
+});
+
+/* ============================================================
+   Documents
+   ============================================================ */
+async function loadDocs(){
+  const el = $('#doc-list'); el.innerHTML = skelCards(3);
+  try{
+    const data = await fetch(API+'/documents').then(r=>r.json());
+    state.docs = data.documents || data || [];
+    $('#nav-doc-count').textContent = state.docs.length;
+    renderDocs(state.docs);
+  }catch(e){ toast('Failed to load docs: '+e.message,'danger') }
+}
+function renderDocs(list){
+  const el = $('#doc-list');
+  if(!list.length){
+    el.innerHTML = '';
+    el.appendChild(emptyState({
+      icon:'📄',
+      title:'No documents yet',
+      body:'Drop a PDF, TXT, or DOCX above. Documents are indexed for RAG search and used to ground chat answers.',
+    }));
+    return;
+  }
+  el.innerHTML = list.map(d=>`
+    <div class="card"><div class="row">
+      <div>
+        <div class="title">${esc(d.filename||d.name||'unnamed')}</div>
+        <div class="meta">${esc(d.content_type||d.type||'')} ${d.size? ' · '+(d.size/1024|0)+' KB':''} ${d.chunks?' · '+d.chunks+' chunks':''}</div>
+      </div>
+      <div class="actions">
+        <button class="btn" data-size="sm" data-view-doc="${esc(d.filename)}">View</button>
+      </div>
+    </div></div>`).join('');
+  el.querySelectorAll('[data-view-doc]').forEach(b=>b.addEventListener('click',()=>{
+    window.open(`${API}/documents/${encodeURIComponent(b.dataset.viewDoc)}/view`, '_blank');
+  }));
+}
+$('#docs-refresh').addEventListener('click', loadDocs);
+$('#search-go').addEventListener('click', doSearch);
+$('#search-q').addEventListener('keydown', e=>{ if(e.key==='Enter') doSearch() });
+async function doSearch(){
+  const q = $('#search-q').value.trim(); if(!q) return loadDocs();
+  try{
+    const r = await api('/rag/search',{method:'POST',body:JSON.stringify({query:q, top_k:10})});
+    const hits = r.results || r.hits || [];
+    const el = $('#doc-list');
+    if(!hits.length){
+      el.innerHTML='';
+      el.appendChild(emptyState({icon:'🔍', title:'No matches', body:`Nothing in the index matched "${q}". Try fewer words or different terms.`}));
+      return;
+    }
+    el.innerHTML = hits.map((h,i)=>`
+      <div class="card">
+        <div class="title">#${i+1} ${esc(h.filename||'')} <span style="color:var(--fg-muted);font-weight:400">score ${(h.score||0).toFixed(3)}</span></div>
+        <div class="meta" style="margin-top:8px;line-height:1.5;white-space:pre-wrap">${esc((h.chunk||'').slice(0,480))}${(h.chunk||'').length>480?'…':''}</div>
+      </div>`).join('');
+  }catch(e){ toast(e.message,'danger') }
+}
+
+const drop = $('#drop'); const fi = $('#file-input');
+drop.addEventListener('click', ()=>fi.click());
+['dragover','dragenter'].forEach(ev=>drop.addEventListener(ev, e=>{e.preventDefault();drop.classList.add('drag')}));
+['dragleave','drop'].forEach(ev=>drop.addEventListener(ev, e=>{e.preventDefault();drop.classList.remove('drag')}));
+drop.addEventListener('drop', e=>{e.preventDefault(); handleFiles(e.dataTransfer.files)});
+fi.addEventListener('change', ()=>handleFiles(fi.files));
+async function handleFiles(files){
+  if(!files||!files.length) return;
+  const fd = new FormData();
+  for(const f of files) fd.append('files', f);
+  try{
+    const r = await fetch(API+'/upload/batch',{method:'POST', body:fd});
+    if(!r.ok) throw new Error(await r.text());
+    toast(`Uploaded ${files.length} file(s)`); loadDocs();
+  }catch(e){ toast('Upload failed: '+e.message,'danger') }
+}
+
+/* ============================================================
+   Jobs
+   ============================================================ */
+async function loadJobs(){
+  const el = $('#job-list'); el.innerHTML = skelCards(2);
+  try{
+    const s = await fetch(API+'/status').then(r=>r.json());
+    const list = s.jobs || [];
+    $('#nav-job-count').textContent = list.length;
+    if(!list.length){
+      el.innerHTML='';
+      el.appendChild(emptyState({
+        icon:'⚙️',
+        title:'All quiet',
+        body:'No active background jobs. OCR, embeddings, and LLM tasks will appear here as they run.',
+      }));
+      return;
+    }
+    el.innerHTML = list.map(j=>{
+      const intent = j.status==='completed'?'success':(j.status==='failed'?'danger':'warn');
+      return `<div class="card"><div class="row">
+        <div>
+          <div class="title">${esc(j.type||j.job_id||'job')} <span class="state-chip" data-intent="${intent}">${esc(j.status||'')}</span></div>
+          <div class="meta">${esc(j.job_id||'')} ${j.progress!=null?' · '+Math.round(j.progress*100)+'%':''} ${j.message?' · '+esc(j.message):''}</div>
+        </div>
+      </div></div>`;
+    }).join('');
+  }catch(e){ toast(e.message,'danger') }
+}
+$('#jobs-refresh').addEventListener('click', loadJobs);
+
+/* ============================================================
+   Settings
+   ============================================================ */
+async function loadSettings(){
+  $('#set-url').textContent = location.origin;
+  try{
+    const h = await bareFetch('/health');
+    $('#set-health').textContent = h.status || 'ok';
+    $('#set-health').dataset.intent = 'success';
+    $('#set-meta').innerHTML = `uptime <b>${esc(h.uptime||'')}</b> · version <b>${esc(h.version||'')}</b>`;
+  }catch{
+    $('#set-health').textContent='offline'; $('#set-health').dataset.intent='danger';
+  }
+  try{
+    const m = await bareFetch('/api/models');
+    const active = m.active || m.current || m.model || '';
+    $('#model-info').textContent = 'Model: ' + (active || m.name || 'unknown');
+    const available = m.available || m.models || [];
+    $('#set-model').innerHTML = `
+      <div class="row" style="justify-content:space-between">
+        <div><div class="title">${esc(active||'unknown')}</div>
+        <div class="meta">Backend: ${esc(m.backend||'—')} · ${available.length||0} available</div></div>
+        <span class="state-chip" data-intent="success">active</span>
+      </div>`;
+  }catch(e){
+    $('#set-model').innerHTML = `<div class="meta">Could not load models: ${esc(e.message)}</div>`;
+  }
+}
+
+/* ============================================================
+   WebSocket live updates
+   ============================================================ */
+function openWS(){
+  try{
+    const url = location.origin.replace(/^http/,'ws')+'/ws';
+    const ws = new WebSocket(url);
+    ws.onopen = ()=>{ $('#conn-pill').innerHTML='<div class="dot"></div>Connected'; $('#conn-pill').dataset.intent='success' };
+    ws.onclose = ()=>{ $('#conn-pill').innerHTML='<div class="dot"></div>Reconnecting…'; $('#conn-pill').dataset.intent='danger'; setTimeout(openWS,3000) };
+    ws.onmessage = ev=>{
+      try{
+        const m = JSON.parse(ev.data);
+        if(m.type==='job_update' || m.type==='job'){ loadJobs() }
+        if(m.type==='case_update'){ loadCases() }
+      }catch{}
+    };
+  }catch{}
+}
+
+/* ============================================================
+   Command Palette (⌘K)
+   ============================================================ */
+const cmdk = (() => {
+  let backdrop=null, input=null, listEl=null, items=[], activeIdx=0;
+
+  function buildItems(query=''){
+    const q = query.toLowerCase().trim();
+    const out = [];
+
+    // --- Navigation ---
+    const nav = [
+      {label:'Go to Chat',      view:'chat',     ic:'💬', section:'Navigate'},
+      {label:'Go to Cases',     view:'cases',    ic:'📁', section:'Navigate'},
+      {label:'Go to Documents', view:'docs',     ic:'📄', section:'Navigate'},
+      {label:'Go to Jobs',      view:'jobs',     ic:'⚙️', section:'Navigate'},
+      {label:'Go to Settings',  view:'settings', ic:'⚙', section:'Navigate'},
+    ];
+    nav.forEach(n => {
+      if(!q || n.label.toLowerCase().includes(q)) out.push({...n, do:()=>gotoView(n.view), meta:'⏎'});
+    });
+
+    // --- Cases (jump + ask) ---
+    state.cases.forEach(c => {
+      const txt = `${c.client_name||''} ${c.case_id} ${c.matter_type||''}`.toLowerCase();
+      if(!q || txt.includes(q)){
+        out.push({
+          label:`${c.client_name||'(unnamed)'}`,
+          meta:c.case_id, ic:'📁', section:'Cases',
+          do:()=>{ chatCase.value = c.case_id; gotoView('chat'); chatInput.focus(); }
+        });
+      }
+    });
+
+    // --- Documents (open in viewer) ---
+    state.docs.forEach(d => {
+      const f = d.filename || d.name || '';
+      if(!q || f.toLowerCase().includes(q)){
+        out.push({
+          label:f, meta:`${d.chunks||0} chunks`, ic:'📄', section:'Documents',
+          do:()=>window.open(`${API}/documents/${encodeURIComponent(f)}/view`,'_blank')
+        });
+      }
+    });
+
+    // --- Ask AI passthrough ---
+    if(q){
+      out.unshift({
+        label:`Ask AI: "${query}"`, meta:'⏎', ic:'✨', section:'Ask',
+        do:()=>{ gotoView('chat'); chatInput.value = query; sendChat(); }
+      });
+    }
+
+    // --- Actions ---
+    const acts = [
+      {label:'New case', ic:'➕', do:()=>$('#case-new').click()},
+      {label:'Upload document', ic:'⬆️', do:()=>{ gotoView('docs'); setTimeout(()=>$('#file-input').click(),120); }},
+      {label:'Clear conversation', ic:'🗑', do:()=>$('#chat-clear').click()},
+      {label:'Refresh cases', ic:'↻', do:loadCases},
+    ];
+    acts.forEach(a=>{
+      if(!q || a.label.toLowerCase().includes(q)) out.push({...a, section:'Actions'});
+    });
+
+    return out.slice(0, 30);
+  }
+
+  function render(){
+    let html = '';
+    let lastSection = null;
+    items.forEach((it,i)=>{
+      if(it.section !== lastSection){
+        html += `<div class="cmdk-section">${esc(it.section)}</div>`;
+        lastSection = it.section;
+      }
+      html += `<div class="cmdk-item${i===activeIdx?' active':''}" data-i="${i}">
+        <span class="ic">${it.ic||'•'}</span>
+        <span>${esc(it.label)}</span>
+        ${it.meta?`<span class="meta">${esc(it.meta)}</span>`:''}
+      </div>`;
+    });
+    if(!items.length) html = `<div class="cmdk-empty">No matches</div>`;
+    listEl.innerHTML = html;
+    listEl.querySelectorAll('.cmdk-item').forEach(el=>{
+      el.addEventListener('click', ()=>{ activeIdx = +el.dataset.i; commit(); });
+      el.addEventListener('mouseenter', ()=>{ activeIdx = +el.dataset.i; updateActive(); });
+    });
+  }
+  function updateActive(){
+    listEl.querySelectorAll('.cmdk-item').forEach((el,i)=>el.classList.toggle('active', i===activeIdx));
+    const cur = listEl.querySelector('.cmdk-item.active');
+    if(cur) cur.scrollIntoView({block:'nearest'});
+  }
+  function commit(){
+    const it = items[activeIdx]; close();
+    if(it && it.do) it.do();
+  }
+  function open(){
+    if(backdrop) return;
+    backdrop = document.createElement('div');
+    backdrop.className = 'cmdk-backdrop';
+    backdrop.innerHTML = `
+      <div class="cmdk" role="dialog" aria-label="Command palette">
+        <input class="cmdk-input" placeholder="Search cases, documents, or ask AI…" />
+        <div class="cmdk-list"></div>
+        <div class="cmdk-foot">
+          <span><span class="kbd">↑↓</span> navigate</span>
+          <span><span class="kbd">⏎</span> open</span>
+          <span><span class="kbd">esc</span> close</span>
+        </div>
+      </div>`;
+    document.body.appendChild(backdrop);
+    input = backdrop.querySelector('.cmdk-input');
+    listEl = backdrop.querySelector('.cmdk-list');
+    items = buildItems(''); activeIdx = 0; render();
+    input.focus();
+    input.addEventListener('input', ()=>{ items = buildItems(input.value); activeIdx = 0; render(); });
+    input.addEventListener('keydown', e=>{ if(e.key==='Escape'){ e.preventDefault(); e.stopPropagation(); close(); } });
+    backdrop.addEventListener('pointerdown', e=>{ if(!e.target.closest('.cmdk')) close(); });
+  }
+  function close(){ if(backdrop){ backdrop.remove(); backdrop=null; } }
+  document.addEventListener('keydown', e=>{
+    const isMeta = e.metaKey || e.ctrlKey;
+    if(isMeta && e.key.toLowerCase()==='k'){ e.preventDefault(); backdrop?close():open(); return; }
+    if(!backdrop) return;
+    if(e.key==='Escape'){ e.preventDefault(); close(); }
+    else if(e.key==='ArrowDown'){ e.preventDefault(); activeIdx = Math.min(items.length-1, activeIdx+1); updateActive(); }
+    else if(e.key==='ArrowUp'){ e.preventDefault(); activeIdx = Math.max(0, activeIdx-1); updateActive(); }
+    else if(e.key==='Enter'){ e.preventDefault(); commit(); }
+  });
+  return { open, close };
+})();
+$('#cmdk-trigger').addEventListener('click', cmdk.open);
+
+/* ============================================================
+   Boot
+   ============================================================ */
+(async ()=>{
+  await loadCases().catch(()=>{});
+  await loadDocs().catch(()=>{});
+  await loadSettings().catch(()=>{});
+  openWS();
+  chatInput.focus();
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Prevents double-click double-firing on Advance, Delete, and Send Chat buttons
- Adds a minimal `.spinner` CSS class and a `withBusy(btn, fn)` helper that disables the button and appends a spinner for the duration of the fetch
- Restores state in `finally` so failed requests re-enable the button

## Test plan
- [ ] Build and run serve, open http://127.0.0.1:8099/
- [ ] Create a case, rapid-click Advance — only one request fires (verify in network tab)
- [ ] Same for Delete and chat Send