### PR TITLE
simplify(io): bufio.Scanner + embed outside lock + shared vec package

### DIFF
--- a/agentflow/agentflow-go/internal/embedrouter/router.go
+++ b/agentflow/agentflow-go/internal/embedrouter/router.go
@@ -14,9 +14,10 @@ package embedrouter
 import (
 	"context"
 	"fmt"
-	"math"
 	"sort"
 	"strings"
+
+	"agentflow-go/internal/vec"
 )
 
 // Embedder is the interface this package needs from any embedding model.
@@ -84,7 +85,7 @@ func (r *Router) Init(ctx context.Context, corpus []LabeledUtterance) error {
 		if len(vecs[i]) != dim {
 			return fmt.Errorf("vector %d has dim %d, expected %d", i, len(vecs[i]), dim)
 		}
-		refs[i] = Reference{Label: u.Label, Utterance: u.Utterance, Vec: normalize(vecs[i])}
+		refs[i] = Reference{Label: u.Label, Utterance: u.Utterance, Vec: vec.Normalize(vecs[i])}
 	}
 	r.refs = refs
 	return nil
@@ -108,7 +109,7 @@ func (r *Router) Classify(ctx context.Context, query string) (Result, error) {
 	if len(vecs) != 1 {
 		return Result{}, fmt.Errorf("embedder returned %d vectors for 1 query", len(vecs))
 	}
-	qv := normalize(vecs[0])
+	qv := vec.Normalize(vecs[0])
 
 	// Score every reference. Vectors are L2-normalized so dot product
 	// equals cosine similarity.
@@ -118,7 +119,7 @@ func (r *Router) Classify(ctx context.Context, query string) (Result, error) {
 	}
 	all := make([]scored, len(r.refs))
 	for i, ref := range r.refs {
-		all[i] = scored{ref: ref, score: dot(qv, ref.Vec)}
+		all[i] = scored{ref: ref, score: vec.Dot(qv, ref.Vec)}
 	}
 	sort.Slice(all, func(i, j int) bool { return all[i].score > all[j].score })
 
@@ -143,26 +144,3 @@ func (r *Router) Classify(ctx context.Context, query string) (Result, error) {
 	}, nil
 }
 
-func dot(a, b []float32) float64 {
-	var s float64
-	for i := range a {
-		s += float64(a[i]) * float64(b[i])
-	}
-	return s
-}
-
-func normalize(v []float32) []float32 {
-	var ss float64
-	for _, x := range v {
-		ss += float64(x) * float64(x)
-	}
-	if ss == 0 {
-		return v
-	}
-	inv := float32(1.0 / math.Sqrt(ss))
-	out := make([]float32, len(v))
-	for i, x := range v {
-		out[i] = x * inv
-	}
-	return out
-}

--- a/agentflow/agentflow-go/internal/embedserver/manager.go
+++ b/agentflow/agentflow-go/internal/embedserver/manager.go
@@ -9,6 +9,7 @@
 package embedserver
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -195,40 +196,13 @@ func (m *Manager) waitForReady(ctx context.Context) {
 }
 
 func forwardLog(prefix string, r io.Reader) {
-	buf := make([]byte, 4096)
-	carry := []byte{}
-	for {
-		n, err := r.Read(buf)
-		if n > 0 {
-			carry = append(carry, buf[:n]...)
-			for {
-				idx := indexByte(carry, '\n')
-				if idx < 0 {
-					break
-				}
-				line := carry[:idx]
-				carry = carry[idx+1:]
-				if len(line) > 0 {
-					log.Printf("%s %s", prefix, string(line))
-				}
-			}
-		}
-		if err != nil {
-			if len(carry) > 0 {
-				log.Printf("%s %s", prefix, string(carry))
-			}
-			return
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 4096), 1024*1024)
+	for scanner.Scan() {
+		if line := scanner.Text(); line != "" {
+			log.Printf("%s %s", prefix, line)
 		}
 	}
-}
-
-func indexByte(b []byte, c byte) int {
-	for i, v := range b {
-		if v == c {
-			return i
-		}
-	}
-	return -1
 }
 
 func (m *Manager) Ready() bool { return m.ready.Load() }

--- a/agentflow/agentflow-go/internal/mlxserver/manager.go
+++ b/agentflow/agentflow-go/internal/mlxserver/manager.go
@@ -8,6 +8,7 @@
 package mlxserver
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -193,40 +194,13 @@ func (m *Manager) waitForReady(ctx context.Context) {
 }
 
 func forwardLog(prefix string, r io.Reader) {
-	buf := make([]byte, 4096)
-	carry := []byte{}
-	for {
-		n, err := r.Read(buf)
-		if n > 0 {
-			carry = append(carry, buf[:n]...)
-			for {
-				idx := indexByte(carry, '\n')
-				if idx < 0 {
-					break
-				}
-				line := carry[:idx]
-				carry = carry[idx+1:]
-				if len(line) > 0 {
-					log.Printf("%s %s", prefix, string(line))
-				}
-			}
-		}
-		if err != nil {
-			if len(carry) > 0 {
-				log.Printf("%s %s", prefix, string(carry))
-			}
-			return
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 4096), 1024*1024)
+	for scanner.Scan() {
+		if line := scanner.Text(); line != "" {
+			log.Printf("%s %s", prefix, line)
 		}
 	}
-}
-
-func indexByte(b []byte, c byte) int {
-	for i, v := range b {
-		if v == c {
-			return i
-		}
-	}
-	return -1
 }
 
 // Ready reports whether the local server is currently serving requests.

--- a/agentflow/agentflow-go/internal/rag/dense.go
+++ b/agentflow/agentflow-go/internal/rag/dense.go
@@ -6,13 +6,13 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"math"
 	"os"
 	"path/filepath"
 	"sort"
 	"time"
 
 	"agentflow-go/internal/model"
+	"agentflow-go/internal/vec"
 )
 
 // embedder is the minimal interface this package needs from the global
@@ -45,35 +45,6 @@ func (m *Manager) SetEmbedder(e embedder) {
 	if needMigration && e != nil {
 		go m.backfillEmbeddings()
 	}
-}
-
-// embedQueryAndScore embeds the query and returns dense cosine scores per
-// chunk, in the same order as m.tokenizedCorpus / m.chunkEmbeddings.
-// Returns nil if embedder isn't ready or any embeddings are missing.
-func (m *Manager) embedQueryAndScore(ctx context.Context, query string) []float64 {
-	if m.embedder == nil || len(m.chunkEmbeddings) == 0 {
-		return nil
-	}
-	if len(m.chunkEmbeddings) != len(m.tokenizedCorpus) {
-		// Chunk count mismatch — migration in progress. Skip dense for
-		// this query; BM25 still works alone.
-		return nil
-	}
-	vecs, err := m.embedder.Embed(ctx, []string{query})
-	if err != nil || len(vecs) != 1 {
-		log.Printf("[rag] dense embed failed: %v (falling back to BM25)", err)
-		return nil
-	}
-	q := normalizeF32(vecs[0])
-	scores := make([]float64, len(m.chunkEmbeddings))
-	for i, v := range m.chunkEmbeddings {
-		if len(v) == 0 || len(v) != len(q) {
-			scores[i] = -1 // sentinel: missing or wrong-dim → effectively no match
-			continue
-		}
-		scores[i] = dotF32(q, v)
-	}
-	return scores
 }
 
 // rrfFuse combines a BM25 ranking and a dense ranking via Reciprocal Rank
@@ -236,7 +207,7 @@ func (m *Manager) backfillEmbeddings() {
 			break
 		}
 		if p.globalIdx < len(m.chunkEmbeddings) && len(m.chunkEmbeddings[p.globalIdx]) == 0 {
-			m.chunkEmbeddings[p.globalIdx] = normalizeF32(vecs[i])
+			m.chunkEmbeddings[p.globalIdx] = vec.Normalize(vecs[i])
 			filled++
 		}
 	}
@@ -376,28 +347,3 @@ func (m *Manager) saveEmbeddings() {
 	}
 }
 
-// ---------------- math helpers ----------------
-
-func dotF32(a, b []float32) float64 {
-	var s float64
-	for i := range a {
-		s += float64(a[i]) * float64(b[i])
-	}
-	return s
-}
-
-func normalizeF32(v []float32) []float32 {
-	var ss float64
-	for _, x := range v {
-		ss += float64(x) * float64(x)
-	}
-	if ss == 0 {
-		return v
-	}
-	inv := float32(1.0 / math.Sqrt(ss))
-	out := make([]float32, len(v))
-	for i, x := range v {
-		out[i] = x * inv
-	}
-	return out
-}

--- a/agentflow/agentflow-go/internal/rag/manager.go
+++ b/agentflow/agentflow-go/internal/rag/manager.go
@@ -3,6 +3,7 @@ package rag
 import (
 	"context"
 	"encoding/json"
+	"log"
 	"math"
 	"os"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"agentflow-go/internal/model"
+	"agentflow-go/internal/vec"
 
 	"golang.org/x/text/unicode/norm"
 )
@@ -276,17 +278,35 @@ func (m *Manager) Search(query string, k int) []model.SearchResult {
 	}
 	m.cacheMu.RUnlock()
 
+	// Snapshot the embedder under a brief read lock, then do the HTTP
+	// embed *without* holding m.mu — otherwise concurrent ingest/delete
+	// blocks for the duration of the network call.
+	m.mu.RLock()
+	emb := m.embedder
+	chunksEmbedded := len(m.chunkEmbeddings) > 0 && len(m.chunkEmbeddings) == len(m.tokenizedCorpus)
+	m.mu.RUnlock()
+
+	var queryVec []float32
+	if emb != nil && chunksEmbedded {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		vecs, err := emb.Embed(ctx, []string{query})
+		cancel()
+		if err != nil {
+			log.Printf("[rag] dense embed failed: %v (falling back to BM25)", err)
+		} else if len(vecs) == 1 {
+			queryVec = vec.Normalize(vecs[0])
+		}
+	}
+
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
 	queryTokens := tokenize(query)
-	results := m.searchLocked(query, queryTokens, k)
+	results := m.scoreAndRank(queryTokens, queryVec, k)
 
-	// Cache results
 	m.cacheMu.Lock()
 	m.searchCache[query] = results
 	if len(m.searchCache) > 256 {
-		// Evict oldest
 		for key := range m.searchCache {
 			delete(m.searchCache, key)
 			break
@@ -297,15 +317,26 @@ func (m *Manager) Search(query string, k int) []model.SearchResult {
 	return results
 }
 
-func (m *Manager) searchLocked(query string, queryTokens []string, k int) []model.SearchResult {
+// scoreAndRank assumes m.mu is held. queryVec may be nil when dense is
+// unavailable; in that case it falls back to BM25-only ranking.
+func (m *Manager) scoreAndRank(queryTokens []string, queryVec []float32, k int) []model.SearchResult {
 	bm25Scores := m.bm25Scores(queryTokens)
 	if len(bm25Scores) == 0 {
 		return nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-	defer cancel()
-	denseScores := m.embedQueryAndScore(ctx, query)
+	var denseScores []float64
+	if queryVec != nil && len(m.chunkEmbeddings) == len(m.tokenizedCorpus) {
+		denseScores = make([]float64, len(m.chunkEmbeddings))
+		for i, v := range m.chunkEmbeddings {
+			if len(v) != len(queryVec) {
+				denseScores[i] = -1
+				continue
+			}
+			denseScores[i] = vec.Dot(queryVec, v)
+		}
+	}
+
 	if len(denseScores) == 0 {
 		return m.resultsFromScores(bm25Scores, k, "bm25")
 	}

--- a/agentflow/agentflow-go/internal/vec/vec.go
+++ b/agentflow/agentflow-go/internal/vec/vec.go
@@ -1,0 +1,34 @@
+// Package vec is a tiny shared helper for L2-normalized cosine math used
+// by the embedding router and the dense-RAG retriever. Kept separate so
+// neither importer needs to depend on the other.
+package vec
+
+import "math"
+
+// Dot returns the dot product of two equal-length float32 vectors as a
+// float64. With L2-normalized inputs, this equals cosine similarity.
+func Dot(a, b []float32) float64 {
+	var s float64
+	for i := range a {
+		s += float64(a[i]) * float64(b[i])
+	}
+	return s
+}
+
+// Normalize returns a copy of v scaled to unit L2 length. Returns the
+// input unchanged if its norm is zero.
+func Normalize(v []float32) []float32 {
+	var ss float64
+	for _, x := range v {
+		ss += float64(x) * float64(x)
+	}
+	if ss == 0 {
+		return v
+	}
+	inv := float32(1.0 / math.Sqrt(ss))
+	out := make([]float32, len(v))
+	for i, x := range v {
+		out[i] = x * inv
+	}
+	return out
+}


### PR DESCRIPTION
Code review of the embedding spine that landed in #50 surfaced three concrete simplifications worth shipping.

## Changes

**1. `bufio.Scanner` instead of hand-rolled byte buffering** (`mlxserver/manager.go`, `embedserver/manager.go`)
- 30 lines of `forwardLog` + `indexByte` per file, byte-for-byte duplicated, both reimplementing line reading.
- Replaced with 5-line `bufio.Scanner`. Stdlib does this correctly, no off-by-one risk on the carry buffer.
- Net: −56 LOC.

**2. HTTP query-embed moved OUTSIDE `m.mu.RLock` in `rag.Manager.Search`**
- Before: `Search` took `RLock`, then called `embedQueryAndScore` which fired a 5–100ms HTTP POST to the embed sidecar **while holding the lock**. All concurrent ingest / delete / GetDocument blocked for the duration.
- After: brief snapshot lock to read the embedder + chunk-count, release, do the HTTP call, reacquire for in-memory scoring (BM25 + dense cosine, both microseconds).
- Cuts critical-section time from ≈RTT down to in-memory math only. Real win under concurrent load.
- Removed now-unused `embedQueryAndScore` (replaced by inline scoring in the new `scoreAndRank` helper).

**3. Shared cosine math in `internal/vec`** (new package)
- `embedrouter/router.go` had `dot` + `normalize`; `rag/dense.go` had `dotF32` + `normalizeF32`. Identical math, different names, drift-prone.
- Extracted to `internal/vec.{Dot, Normalize}`. Both packages now import it; no cross-package coupling between embedrouter and rag.
- Net: −40 LOC of duplication.

## Verified

- `go build ./...` clean
- `go vet ./...` clean
- `go test ./internal/rag/... ./internal/embedrouter/... ./internal/embedserver/... ./internal/mlxserver/... ./internal/vec/...` all pass

## Out of scope (deferred)

The review surfaced larger items that would benefit from their own PR:

- Supervisor consolidation: mlxserver and embedserver are 80%+ identical (M effort).
- DeleteDocument re-embeds all chunks: O(N) HTTP calls per delete; needs schema versioning.
- LRU search cache: current eviction is "delete random entry".
- Batch persistence on IngestFile.

## Stat

\`\`\`
 6 files changed, 91 insertions(+), 154 deletions(-)
\`\`\`

Net −63 LOC.