### PR TITLE
feat(materials): DocumentClassifier with category mapping

### DIFF
--- a/agentflow/AgentFlowUI/Package.swift
+++ b/agentflow/AgentFlowUI/Package.swift
@@ -14,6 +14,11 @@ let package = Package(
             swiftSettings: [
                 .unsafeFlags(["-framework", "AppKit"])
             ]
+        ),
+        .testTarget(
+            name: "AgentFlowTests",
+            dependencies: ["AgentFlowUI"],
+            path: "Tests/AgentFlowTests"
         )
     ]
 )

--- a/agentflow/AgentFlowUI/Sources/AgentFlowUI/DocumentClassifier.swift
+++ b/agentflow/AgentFlowUI/Sources/AgentFlowUI/DocumentClassifier.swift
@@ -1,0 +1,130 @@
+import Foundation
+import SwiftUI
+
+// MARK: - Category model
+
+/// Coarse-grained category buckets for documents shown in the materials hub.
+/// Each case carries a presentation label, an SF Symbol name, and a tint so
+/// callers can render a consistent badge without hard-coding strings.
+enum DocCategory: String, CaseIterable, Identifiable {
+    case pleadings
+    case evidence
+    case idAndContracts
+    case communications
+    case courtForms
+    case other
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .pleadings:        return "Pleadings"
+        case .evidence:         return "Evidence"
+        case .idAndContracts:   return "ID & contracts"
+        case .communications:   return "Communications"
+        case .courtForms:       return "Court forms"
+        case .other:            return "Other"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .pleadings:        return "doc.text.fill"
+        case .evidence:         return "magnifyingglass.circle.fill"
+        case .idAndContracts:   return "person.text.rectangle.fill"
+        case .communications:   return "bubble.left.and.bubble.right.fill"
+        case .courtForms:       return "building.columns.fill"
+        case .other:            return "doc.fill"
+        }
+    }
+
+    var tint: Color {
+        switch self {
+        case .pleadings:        return .blue
+        case .evidence:         return .purple
+        case .idAndContracts:   return .teal
+        case .communications:   return .orange
+        case .courtForms:       return .indigo
+        case .other:            return .gray
+        }
+    }
+}
+
+// MARK: - Classifier
+
+/// Pure-logic mapping from a document's backend doctype slug (or filename, if
+/// no doctype is available) to a `DocCategory`.
+///
+/// The doctype slugs come from the Go backend's intake classifier; new slugs
+/// added there should be reflected in `categoryForDoctype` below. The filename
+/// heuristic is a best-effort fallback for legacy uploads or files where the
+/// classifier hasn't run yet.
+enum DocumentClassifier {
+
+    /// Map a document to its category. Prefer the backend doctype slug when
+    /// present; fall back to filename / extension heuristics otherwise.
+    static func classify(filename: String, doctype: String?) -> DocCategory {
+        if let slug = doctype?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+           !slug.isEmpty,
+           slug != "other",
+           let category = categoryForDoctype(slug) {
+            return category
+        }
+        return categoryForFilename(filename)
+    }
+
+    // MARK: Doctype slugs
+
+    private static func categoryForDoctype(_ slug: String) -> DocCategory? {
+        switch slug {
+        case "civil_complaint",
+             "civil_petition_fragment",
+             "power_of_attorney",
+             "litigation_service_address_confirmation":
+            return .pleadings
+
+        case "wechat_chat_screenshot",
+             "printed_chat_evidence",
+             "wechat_pay_receipt",
+             "iou_debt_note",
+             "spreadsheet_shipment_ledger":
+            return .evidence
+
+        case "resident_id_card",
+             "household_registration_query_result":
+            return .idAndContracts
+
+        case "online_case_filing_confirmation",
+             "litigation_fee_refund_account_form",
+             "court_form_other",
+             "legal_statute_excerpt":
+            return .courtForms
+
+        default:
+            return nil
+        }
+    }
+
+    // MARK: Filename heuristics
+
+    private static func categoryForFilename(_ filename: String) -> DocCategory {
+        let lowered = filename.lowercased()
+        for (category, keywords) in filenameKeywords {
+            if keywords.contains(where: { lowered.contains($0) }) {
+                return category
+            }
+        }
+        return .other
+    }
+
+    /// Ordered keyword table; first match wins. Order matters because some
+    /// substrings overlap (e.g. an ID-card filename containing "id" should
+    /// not be reclassified as evidence by a later rule).
+    private static let filenameKeywords: [(DocCategory, [String])] = [
+        (.pleadings,        ["起诉状", "complaint", "petition", "motion"]),
+        (.evidence,         ["证据", "凭证", "截图", "evidence", "screenshot", "receipt"]),
+        (.idAndContracts,   ["身份证", "户口", "id", "contract", "agreement"]),
+        (.courtForms,       ["传票", "送达", "summons", "hearing"]),
+        (.communications,   ["chat", "email", "letter", "correspondence"]),
+    ]
+}

--- a/agentflow/AgentFlowUI/Tests/AgentFlowTests/DocumentClassifierTests.swift
+++ b/agentflow/AgentFlowUI/Tests/AgentFlowTests/DocumentClassifierTests.swift
@@ -1,0 +1,127 @@
+import XCTest
+@testable import AgentFlowUI
+
+final class DocumentClassifierTests: XCTestCase {
+
+    // MARK: - Doctype slug → category
+
+    func testDoctypePleadings() {
+        XCTAssertEqual(
+            DocumentClassifier.classify(filename: "anything.pdf",
+                                        doctype: "civil_complaint"),
+            .pleadings
+        )
+        XCTAssertEqual(
+            DocumentClassifier.classify(filename: "x.docx",
+                                        doctype: "power_of_attorney"),
+            .pleadings
+        )
+    }
+
+    func testDoctypeEvidence() {
+        XCTAssertEqual(
+            DocumentClassifier.classify(filename: "scan.jpg",
+                                        doctype: "wechat_pay_receipt"),
+            .evidence
+        )
+        XCTAssertEqual(
+            DocumentClassifier.classify(filename: "ledger.xlsx",
+                                        doctype: "spreadsheet_shipment_ledger"),
+            .evidence
+        )
+    }
+
+    func testDoctypeIdAndContracts() {
+        XCTAssertEqual(
+            DocumentClassifier.classify(filename: "front.jpg",
+                                        doctype: "resident_id_card"),
+            .idAndContracts
+        )
+    }
+
+    func testDoctypeCourtForms() {
+        XCTAssertEqual(
+            DocumentClassifier.classify(filename: "filing.pdf",
+                                        doctype: "online_case_filing_confirmation"),
+            .courtForms
+        )
+        XCTAssertEqual(
+            DocumentClassifier.classify(filename: "statute.pdf",
+                                        doctype: "legal_statute_excerpt"),
+            .courtForms
+        )
+    }
+
+    // MARK: - Filename heuristics
+
+    func testFilenameChinesePleadings() {
+        XCTAssertEqual(
+            DocumentClassifier.classify(filename: "原告起诉状-final.pdf",
+                                        doctype: nil),
+            .pleadings
+        )
+    }
+
+    func testFilenameChineseEvidence() {
+        XCTAssertEqual(
+            DocumentClassifier.classify(filename: "微信聊天截图-2025.png",
+                                        doctype: ""),
+            .evidence
+        )
+    }
+
+    func testFilenameEnglishCommunications() {
+        XCTAssertEqual(
+            DocumentClassifier.classify(filename: "client_email_thread.eml",
+                                        doctype: nil),
+            .communications
+        )
+    }
+
+    func testFilenameEnglishCourtForms() {
+        XCTAssertEqual(
+            DocumentClassifier.classify(filename: "summons_2024-03.pdf",
+                                        doctype: nil),
+            .courtForms
+        )
+    }
+
+    func testFilenameIdAndContracts() {
+        XCTAssertEqual(
+            DocumentClassifier.classify(filename: "rental_agreement.pdf",
+                                        doctype: nil),
+            .idAndContracts
+        )
+    }
+
+    func testFilenameOtherFallback() {
+        XCTAssertEqual(
+            DocumentClassifier.classify(filename: "random_file.bin",
+                                        doctype: nil),
+            .other
+        )
+    }
+
+    // MARK: - Doctype "other" falls through to filename
+
+    func testDoctypeOtherFallsThroughToFilenameHeuristics() {
+        // doctype == "other" should be ignored and filename used instead
+        XCTAssertEqual(
+            DocumentClassifier.classify(filename: "complaint_v3.pdf",
+                                        doctype: "other"),
+            .pleadings
+        )
+    }
+
+    // MARK: - Category surface
+
+    func testEachCategoryHasNonEmptyPresentation() {
+        for category in DocCategory.allCases {
+            XCTAssertFalse(category.label.isEmpty,
+                           "label empty for \(category)")
+            XCTAssertFalse(category.systemImage.isEmpty,
+                           "systemImage empty for \(category)")
+            XCTAssertEqual(category.id, category.rawValue)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `DocumentClassifier.swift` with a `DocCategory` enum (pleadings, evidence, idAndContracts, communications, courtForms, other) carrying label, SF Symbol, and tint for each bucket.
- `DocumentClassifier.classify(filename:doctype:)` prefers the backend doctype slug, falling back to a small ordered keyword table over the lowercased filename (Chinese + English keywords).
- Wires up a `Tests/AgentFlowTests` target in `Package.swift` and adds 12 unit tests covering each doctype family, every filename heuristic branch, and the doctype="other" fall-through.

## Test plan
- [x] `swift build` from `agentflow/AgentFlowUI/`
- [x] `swift test` from `agentflow/AgentFlowUI/` — 12 tests pass