### PR TITLE
feat(client): DocumentInfo model + listDocumentInfo / documentThumbnail APIClient methods

### DIFF
--- a/agentflow/AgentFlowUI/Package.swift
+++ b/agentflow/AgentFlowUI/Package.swift
@@ -14,6 +14,11 @@ let package = Package(
             swiftSettings: [
                 .unsafeFlags(["-framework", "AppKit"])
             ]
+        ),
+        .testTarget(
+            name: "AgentFlowTests",
+            dependencies: ["AgentFlowUI"],
+            path: "Tests/AgentFlowTests"
         )
     ]
 )

--- a/agentflow/AgentFlowUI/Sources/AgentFlowUI/APIClient.swift
+++ b/agentflow/AgentFlowUI/Sources/AgentFlowUI/APIClient.swift
@@ -201,6 +201,37 @@ final class APIClient: ObservableObject {
         return base.appendingPathComponent("v1/documents/\(enc)/view")
     }
 
+    /// GET /v1/cases/{id}/documents/list — per-file metadata for the matter.
+    func listDocumentInfo(caseID: String) async throws -> [DocumentInfo] {
+        struct Resp: Decodable { let documents: [DocumentInfo]? }
+        var req = URLRequest(url: base.appendingPathComponent("v1/cases/\(caseID)/documents/list"))
+        req.timeoutInterval = 30
+        let (data, resp) = try await URLSession.shared.data(for: req)
+        try check(resp, data: data)
+        // Tolerate either a bare array or {"documents": [...]} envelope.
+        if let arr = try? decoder.decode([DocumentInfo].self, from: data) { return arr }
+        return (try decoder.decode(Resp.self, from: data)).documents ?? []
+    }
+
+    /// GET /v1/documents/{name}/thumbnail?size=128 — returns PNG bytes.
+    /// Caller wraps in NSImage / SwiftUI Image as needed.
+    func documentThumbnail(filename: String, size: Int = 128) async throws -> Data {
+        var req = URLRequest(url: documentThumbnailURL(filename: filename, size: size))
+        req.timeoutInterval = 30
+        let (data, resp) = try await URLSession.shared.data(for: req)
+        try check(resp, data: data)
+        return data
+    }
+
+    /// Convenience URL builder for AsyncImage callers.
+    func documentThumbnailURL(filename: String, size: Int = 128) -> URL {
+        let enc = filename.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? filename
+        var comps = URLComponents(url: base.appendingPathComponent("v1/documents/\(enc)/thumbnail"),
+                                  resolvingAgainstBaseURL: false)!
+        comps.queryItems = [URLQueryItem(name: "size", value: String(size))]
+        return comps.url!
+    }
+
     // MARK: - Jobs
 
     struct JobStatus: Decodable {

--- a/agentflow/AgentFlowUI/Sources/AgentFlowUI/Models.swift
+++ b/agentflow/AgentFlowUI/Sources/AgentFlowUI/Models.swift
@@ -131,3 +131,16 @@ enum WorkflowGuidance {
         }
     }
 }
+
+// MARK: - Document metadata
+
+/// Per-file metadata returned by `/v1/cases/{id}/documents/list`.
+struct DocumentInfo: Codable, Identifiable, Hashable {
+    var id: String { filename }
+    let filename: String
+    let doctype: String?       // backend slug; nil/empty when unknown
+    let ocr_indexed: Bool?
+    let rag_indexed: Bool?
+    let size_bytes: Int64?
+    let modified_at: Date?
+}

--- a/agentflow/AgentFlowUI/Tests/AgentFlowTests/DocumentInfoSmokeTests.swift
+++ b/agentflow/AgentFlowUI/Tests/AgentFlowTests/DocumentInfoSmokeTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+@testable import AgentFlowUI
+
+final class DocumentInfoSmokeTests: XCTestCase {
+    /// Decodes a fixture JSON matching the `/v1/cases/{id}/documents/list`
+    /// response shape into `[DocumentInfo]`.
+    func test_decodesFixtureIntoDocumentInfoArray() throws {
+        let json = """
+        [
+          {
+            "filename": "complaint.pdf",
+            "doctype": "complaint",
+            "ocr_indexed": true,
+            "rag_indexed": true,
+            "size_bytes": 204813,
+            "modified_at": "2026-04-30T12:34:56Z"
+          },
+          {
+            "filename": "exhibit_a.png",
+            "doctype": null,
+            "ocr_indexed": false,
+            "rag_indexed": null,
+            "size_bytes": 18244,
+            "modified_at": "2026-05-01T08:15:00.123Z"
+          },
+          {
+            "filename": "scratch.txt"
+          }
+        ]
+        """.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .custom { dec in
+            let s = try dec.singleValueContainer().decode(String.self)
+            let iso = ISO8601DateFormatter()
+            iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            if let d = iso.date(from: s) { return d }
+            iso.formatOptions = [.withInternetDateTime]
+            if let d = iso.date(from: s) { return d }
+            throw DecodingError.dataCorruptedError(in: try dec.singleValueContainer(),
+                debugDescription: "Unparseable date \(s)")
+        }
+
+        let docs = try decoder.decode([DocumentInfo].self, from: json)
+
+        XCTAssertEqual(docs.count, 3)
+
+        XCTAssertEqual(docs[0].filename, "complaint.pdf")
+        XCTAssertEqual(docs[0].id, "complaint.pdf")           // id == filename
+        XCTAssertEqual(docs[0].doctype, "complaint")
+        XCTAssertEqual(docs[0].ocr_indexed, true)
+        XCTAssertEqual(docs[0].rag_indexed, true)
+        XCTAssertEqual(docs[0].size_bytes, 204813)
+        XCTAssertNotNil(docs[0].modified_at)
+
+        XCTAssertEqual(docs[1].filename, "exhibit_a.png")
+        XCTAssertNil(docs[1].doctype)
+        XCTAssertEqual(docs[1].ocr_indexed, false)
+        XCTAssertNil(docs[1].rag_indexed)
+        XCTAssertNotNil(docs[1].modified_at)
+
+        // Sparse object — every optional should decode to nil without error.
+        XCTAssertEqual(docs[2].filename, "scratch.txt")
+        XCTAssertNil(docs[2].doctype)
+        XCTAssertNil(docs[2].ocr_indexed)
+        XCTAssertNil(docs[2].rag_indexed)
+        XCTAssertNil(docs[2].size_bytes)
+        XCTAssertNil(docs[2].modified_at)
+    }
+}


### PR DESCRIPTION
## Summary

Adds the data-layer Swift types and HTTP-client methods that consume the new per-file document metadata and thumbnail backend endpoints (Units 1 & 2 in the parallel rollout).

- `DocumentInfo` struct in `Models.swift` (filename, doctype, ocr/rag indexed flags, size, mtime; tolerant decoding of optional fields)
- `APIClient.listDocumentInfo(caseID:)` — `GET /v1/cases/{id}/documents/list`, tolerates either bare-array or `{"documents":[...]}` envelope shape
- `APIClient.documentThumbnail(filename:size:)` — `GET /v1/documents/{name}/thumbnail?size=...` returning PNG bytes
- `APIClient.documentThumbnailURL(filename:size:)` — convenience builder for `AsyncImage` callers
- Adds `Tests/AgentFlowTests` test target with `DocumentInfoSmokeTests.swift` that decodes a fixture JSON into `[DocumentInfo]`

If Units 1 & 2 haven't landed at integration time the methods will simply return 404 — that's expected.

## Test plan

- [x] `swift build` from `AgentFlowUI/` succeeds
- [x] `swift test` from `AgentFlowUI/` — `DocumentInfoSmokeTests.test_decodesFixtureIntoDocumentInfoArray` passes
- [ ] Once Units 1 & 2 land: hit `/v1/cases/{id}/documents/list` and `/v1/documents/{name}/thumbnail?size=128` from a UI caller and confirm round-trip