### PR TITLE
feat(materials): MaterialsSelection observable + bulk action bar

### DIFF
--- a/agentflow/AgentFlowUI/Package.swift
+++ b/agentflow/AgentFlowUI/Package.swift
@@ -14,6 +14,11 @@ let package = Package(
             swiftSettings: [
                 .unsafeFlags(["-framework", "AppKit"])
             ]
+        ),
+        .testTarget(
+            name: "AgentFlowTests",
+            dependencies: ["AgentFlowUI"],
+            path: "Tests/AgentFlowTests"
         )
     ]
 )

--- a/agentflow/AgentFlowUI/Sources/AgentFlowUI/MaterialsSelection.swift
+++ b/agentflow/AgentFlowUI/Sources/AgentFlowUI/MaterialsSelection.swift
@@ -1,0 +1,106 @@
+import SwiftUI
+
+// MARK: - MaterialsSelection
+//
+// Multi-select state for the Materials pane. Holds a set of currently
+// selected filenames and exposes minimal mutation primitives the parent
+// list (and the bulk-action bar below) drive. Single source of truth so
+// both row checkmarks and the action bar see consistent state.
+
+@MainActor
+final class MaterialsSelection: ObservableObject {
+    @Published private(set) var selected: Set<String> = []
+
+    /// Toggle membership of `filename` in the selection.
+    func toggle(_ filename: String) {
+        if selected.insert(filename).inserted == false {
+            selected.remove(filename)
+        }
+    }
+
+    /// Whether `filename` is currently selected.
+    func contains(_ filename: String) -> Bool {
+        selected.contains(filename)
+    }
+
+    /// Drop the entire selection.
+    func clear() {
+        selected.removeAll()
+    }
+
+    /// Replace the selection with the given filenames (deduplicated).
+    func selectAll(_ filenames: [String]) {
+        selected = Set(filenames)
+    }
+}
+
+// MARK: - MaterialsBulkActionBar
+//
+// Bottom action bar that appears when the user has one or more files
+// selected in the Materials pane. The parent is responsible for mounting
+// this view via `.safeAreaInset(edge: .bottom) { ... }`. When the
+// selection is empty the view collapses to `EmptyView()` so the host
+// pane regains its full height with no visual gap.
+
+struct MaterialsBulkActionBar: View {
+    @ObservedObject var selection: MaterialsSelection
+    let onDelete: (Set<String>) -> Void
+    let onMove: (Set<String>) -> Void
+    let onDownload: (Set<String>) -> Void
+    let onPreview: (Set<String>) -> Void
+
+    var body: some View {
+        if selection.selected.isEmpty {
+            EmptyView()
+        } else {
+            HStack(spacing: AF.Space.s) {
+                Text("\(selection.selected.count) selected")
+                    .font(.callout.weight(.semibold))
+
+                Spacer()
+
+                Button("Preview") { onPreview(selection.selected) }
+                    .buttonStyle(.bordered)
+
+                Button("Download") { onDownload(selection.selected) }
+                    .buttonStyle(.bordered)
+
+                Button("Move…") { onMove(selection.selected) }
+                    .buttonStyle(.bordered)
+
+                Button(role: .destructive) {
+                    onDelete(selection.selected)
+                } label: {
+                    Text("Delete")
+                }
+                .buttonStyle(.bordered)
+                .tint(.red)
+
+                Button {
+                    selection.clear()
+                } label: {
+                    Image(systemName: "xmark")
+                        .imageScale(.small)
+                }
+                .buttonStyle(.borderless)
+                .help("Clear selection")
+            }
+            .padding(.horizontal, AF.Space.m)
+            .padding(.vertical, AF.Space.s)
+            .background(.bar)
+        }
+    }
+}
+
+#Preview {
+    let s = MaterialsSelection()
+    s.selectAll(["a.pdf", "b.pdf", "c.docx"])
+    return MaterialsBulkActionBar(
+        selection: s,
+        onDelete: { _ in },
+        onMove: { _ in },
+        onDownload: { _ in },
+        onPreview: { _ in }
+    )
+    .frame(width: 600)
+}

--- a/agentflow/AgentFlowUI/Tests/AgentFlowTests/MaterialsSelectionTests.swift
+++ b/agentflow/AgentFlowUI/Tests/AgentFlowTests/MaterialsSelectionTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import AgentFlowUI
+
+@MainActor
+final class MaterialsSelectionTests: XCTestCase {
+
+    func testToggleAddsThenRemoves() {
+        let s = MaterialsSelection()
+        XCTAssertTrue(s.selected.isEmpty)
+
+        s.toggle("a.pdf")
+        XCTAssertEqual(s.selected, ["a.pdf"])
+
+        s.toggle("a.pdf")
+        XCTAssertTrue(s.selected.isEmpty)
+    }
+
+    func testContainsReflectsMembership() {
+        let s = MaterialsSelection()
+        XCTAssertFalse(s.contains("a.pdf"))
+
+        s.toggle("a.pdf")
+        XCTAssertTrue(s.contains("a.pdf"))
+        XCTAssertFalse(s.contains("b.pdf"))
+    }
+
+    func testClearEmptiesSelection() {
+        let s = MaterialsSelection()
+        s.selectAll(["a.pdf", "b.pdf", "c.docx"])
+        XCTAssertEqual(s.selected.count, 3)
+
+        s.clear()
+        XCTAssertTrue(s.selected.isEmpty)
+    }
+
+    func testSelectAllReplacesSelectionAndDedupes() {
+        let s = MaterialsSelection()
+        s.toggle("old.pdf")
+
+        s.selectAll(["a.pdf", "b.pdf", "a.pdf"])
+        XCTAssertEqual(s.selected, ["a.pdf", "b.pdf"])
+        XCTAssertFalse(s.contains("old.pdf"))
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `MaterialsSelection` (`@MainActor ObservableObject`) holding selected filenames with `toggle` / `contains` / `clear` / `selectAll`.
- Adds `MaterialsBulkActionBar` SwiftUI view: bottom action bar (`Preview` / `Download` / `Move…` / `Delete` + clear) intended to mount via `.safeAreaInset(edge: .bottom)`. Hidden when nothing is selected.
- Wires up an `AgentFlowTests` test target with 4 unit tests covering the public API.

## Test plan
- [x] `swift build` passes in `AgentFlowUI/`
- [x] `swift test` — 4 new tests pass (toggle / contains / clear / selectAll)
- [ ] Integration unit mounts the bar in the Materials pane and verifies it renders against a populated selection