### PR TITLE
feat(server): documents/list endpoint with per-file metadata

### DIFF
--- a/agentflow/agentflow-go/internal/server/handlers_case.go
+++ b/agentflow/agentflow-go/internal/server/handlers_case.go
@@ -55,6 +55,10 @@ func (s *Server) handleCases(w http.ResponseWriter, r *http.Request) {
 		}
 		if len(parts) >= 3 {
 			next := parts[2]
+			if next == "list" && len(parts) == 3 && r.Method == http.MethodGet {
+				s.handleListCaseDocuments(w, r, caseID)
+				return
+			}
 			if next == "generate" || strings.HasPrefix(next, "gen-") {
 				s.handleDocumentsRoutes(w, r, caseID, parts[2:])
 				return

--- a/agentflow/agentflow-go/internal/server/handlers_doc.go
+++ b/agentflow/agentflow-go/internal/server/handlers_doc.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 )
 
 func unescapeURLPathSegment(s string) string {
@@ -209,4 +210,70 @@ func (s *Server) resolveDocDiskPath(name string) (string, bool) {
 	}
 
 	return "", false
+}
+
+// caseDocumentMeta is the per-file payload returned from
+// GET /v1/cases/{id}/documents/list.
+type caseDocumentMeta struct {
+	Filename   string `json:"filename"`
+	Doctype    string `json:"doctype"`
+	OCRIndexed bool   `json:"ocr_indexed"`
+	RAGIndexed bool   `json:"rag_indexed"`
+	SizeBytes  int64  `json:"size_bytes"`
+	ModifiedAt string `json:"modified_at"`
+}
+
+// handleListCaseDocuments returns the file-attachment metadata table for a case.
+// Failures stat'ing an individual file are non-fatal — the entry is still
+// returned with size_bytes=0 and an empty modified_at so the UI can flag the
+// missing file rather than failing the whole listing.
+func (s *Server) handleListCaseDocuments(w http.ResponseWriter, r *http.Request, caseID string) {
+	if r.Method != http.MethodGet {
+		s.writeError(w, http.StatusMethodNotAllowed, "GET required")
+		return
+	}
+
+	c, ok := s.workflow.GetCaseSnapshot(caseID)
+	if !ok {
+		s.writeError(w, http.StatusNotFound, "Case not found")
+		return
+	}
+
+	doctypes := make(map[string]string, len(c.AIFileSummaries))
+	for _, row := range c.AIFileSummaries {
+		fn, _ := row["filename"].(string)
+		if fn == "" {
+			continue
+		}
+		dt, _ := row["doctype"].(string)
+		doctypes[fn] = dt
+	}
+
+	out := make([]caseDocumentMeta, 0, len(c.UploadedDocuments))
+	for _, filename := range c.UploadedDocuments {
+		entry := caseDocumentMeta{
+			Filename: filename,
+			Doctype:  doctypes[filename],
+		}
+
+		if path, found := s.resolveDocDiskPath(filename); found {
+			if info, err := os.Stat(path); err == nil {
+				entry.SizeBytes = info.Size()
+				entry.ModifiedAt = info.ModTime().UTC().Format(time.RFC3339)
+			}
+			if s.ocrCache != nil {
+				if _, hit := s.ocrCache.Get(path); hit {
+					entry.OCRIndexed = true
+				}
+			}
+		}
+
+		if doc, ok := s.rag.GetDocumentFlex(filename); ok && len(doc.Chunks) > 0 {
+			entry.RAGIndexed = true
+		}
+
+		out = append(out, entry)
+	}
+
+	s.writeJSON(w, http.StatusOK, out)
 }

--- a/agentflow/agentflow-go/internal/server/handlers_doc_list_test.go
+++ b/agentflow/agentflow-go/internal/server/handlers_doc_list_test.go
@@ -1,0 +1,120 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"agentflow-go/internal/config"
+)
+
+// TestListCaseDocumentsJSONShape verifies that GET /v1/cases/{id}/documents/list
+// returns a JSON array of objects, each carrying the six spec fields with the
+// correct types: filename(string), doctype(string), ocr_indexed(bool),
+// rag_indexed(bool), size_bytes(int64), modified_at(string).
+func TestListCaseDocumentsJSONShape(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "doc-list-test-*")
+	if err != nil {
+		t.Fatalf("mkdtemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tempDir) })
+
+	cfg := &config.Config{
+		DataDir:        tempDir,
+		IsAppleSilicon: false,
+		OllamaURL:      "http://localhost:11434",
+		MaxCases:       10,
+		MaxConcurrent:  1,
+	}
+	s := New(cfg)
+
+	// Create a case and attach a document. Drop matching bytes on disk so the
+	// handler can stat them and report a nonzero size + mtime.
+	c := s.workflow.CreateCase("Test Client", "Civil", "Test", "")
+	docsDir := filepath.Join(tempDir, "docs")
+	if err := os.MkdirAll(docsDir, 0o755); err != nil {
+		t.Fatalf("mkdir docs: %v", err)
+	}
+	docName := "evidence.pdf"
+	docPath := filepath.Join(docsDir, docName)
+	docBody := []byte("hello world")
+	if err := os.WriteFile(docPath, docBody, 0o644); err != nil {
+		t.Fatalf("write doc: %v", err)
+	}
+	s.workflow.AttachDocument(c.CaseID, docName)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/cases/"+c.CaseID+"/documents/list", nil)
+	rr := httptest.NewRecorder()
+	s.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	var got []map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v body=%s", err, rr.Body.String())
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 entry, got %d (body=%s)", len(got), rr.Body.String())
+	}
+
+	entry := got[0]
+	for _, field := range []string{"filename", "doctype", "ocr_indexed", "rag_indexed", "size_bytes", "modified_at"} {
+		if _, ok := entry[field]; !ok {
+			t.Errorf("missing field %q in entry: %v", field, entry)
+		}
+	}
+
+	if fn, _ := entry["filename"].(string); fn != docName {
+		t.Errorf("filename = %q, want %q", fn, docName)
+	}
+	// doctype is a string (empty when AIFileSummaries.doctype is unset).
+	if _, ok := entry["doctype"].(string); !ok {
+		t.Errorf("doctype is not a string: %T", entry["doctype"])
+	}
+	if _, ok := entry["ocr_indexed"].(bool); !ok {
+		t.Errorf("ocr_indexed is not a bool: %T", entry["ocr_indexed"])
+	}
+	if _, ok := entry["rag_indexed"].(bool); !ok {
+		t.Errorf("rag_indexed is not a bool: %T", entry["rag_indexed"])
+	}
+	// size_bytes round-trips through JSON as a float64 — verify it's the file size.
+	size, ok := entry["size_bytes"].(float64)
+	if !ok {
+		t.Errorf("size_bytes is not a number: %T", entry["size_bytes"])
+	} else if int(size) != len(docBody) {
+		t.Errorf("size_bytes = %v, want %d", size, len(docBody))
+	}
+	if mt, _ := entry["modified_at"].(string); mt == "" {
+		t.Errorf("modified_at is empty for an existing file")
+	}
+}
+
+// TestListCaseDocumentsCaseNotFound verifies the endpoint 404s on an unknown case.
+func TestListCaseDocumentsCaseNotFound(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "doc-list-test-*")
+	if err != nil {
+		t.Fatalf("mkdtemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tempDir) })
+
+	cfg := &config.Config{
+		DataDir:       tempDir,
+		OllamaURL:     "http://localhost:11434",
+		MaxCases:      10,
+		MaxConcurrent: 1,
+	}
+	s := New(cfg)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/cases/nonexistent/documents/list", nil)
+	rr := httptest.NewRecorder()
+	s.mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404, body = %s", rr.Code, rr.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary
- Add `GET /v1/cases/{id}/documents/list` returning a JSON array of `{filename, doctype, ocr_indexed, rag_indexed, size_bytes, modified_at}` per uploaded document.
- Wire the new path into `handleCases` alongside the existing `/documents/...` namespaces (generated docs, reassign, delete-by-filename).
- Drives the storage UI from a single round trip instead of fanning out per-file metadata requests.

## Implementation notes
- `doctype` is read from `Case.AIFileSummaries[].doctype` (populated by Unit 3); empty string when unknown.
- `ocr_indexed` checks the content-addressed `ocrCache` against the resolved disk path — same lookup as `/v1/documents/{name}/text`.
- `rag_indexed` is true when `rag.Manager.GetDocumentFlex` finds chunks attributed to the filename.
- `size_bytes` and `modified_at` come from `os.Stat` on the resolved path; missing files yield `0` and `""` rather than failing the listing.

## Test plan
- [x] Unit: `TestListCaseDocumentsJSONShape` and `TestListCaseDocumentsCaseNotFound` in `handlers_doc_list_test.go`.
- [x] Full package run: `go test ./...` passes.
- [x] E2E: server returns the expected shape with all 6 fields:
  ```json
  [{"filename":"sample.pdf","doctype":"","ocr_indexed":false,"rag_indexed":true,"size_bytes":15,"modified_at":"2026-05-01T23:55:19Z"}]
  ```